### PR TITLE
[v1.5] Kickoff: 이슈 맵핑 + 실행 보드 초기화

### DIFF
--- a/docs/v1.5-execution-board.md
+++ b/docs/v1.5-execution-board.md
@@ -1,0 +1,32 @@
+# Osori v1.5 실행 보드
+
+상태: IN_PROGRESS
+기준 문서: `docs/roadmap-v1.5.md`
+트래킹 이슈: #13
+
+---
+
+## Phase 1 (v1.5.0-rc1)
+
+- [ ] #8 `[P0-A] /doctor 레지스트리 건강검진`
+- [ ] #9 `[P0-B] /root-remove 안전 삭제`
+- [ ] #10 `[P0-C] /switch 다중 매치 UX`
+
+## Phase 2 (v1.5.0)
+
+- [ ] #11 `[P1-D] GitHub PR/Issue 카운트 TTL 캐시`
+- [ ] #12 `[P1-E] Alias/Favorite`
+
+---
+
+## 운영 규칙
+
+1. 모든 구현 PR은 최소 1개 이슈를 `Closes #N`으로 연결한다.
+2. 범위 변경 시 `docs/roadmap-v1.5.md` 변경 이력을 먼저 업데이트한다.
+3. 테스트는 `tests/run_tests.sh` 기준 0 fail 유지.
+
+---
+
+## 진행 로그
+
+- 2026-02-16: 이슈 #8~#13 생성, 실행 보드 초기화.


### PR DESCRIPTION
## 목적
v1.5 roadmap(FROZEN) 기반으로 구현 작업을 시작하기 위한 트래킹/보드 PR입니다.

## 포함 내용
- `docs/v1.5-execution-board.md` 추가
  - Phase 1/2 이슈 링크 반영
  - 운영 규칙/진행 로그 초기화

## 연결 이슈
- Closes #13
- Related: #8, #9, #10, #11, #12

## 체크리스트
- [x] roadmap 기반 이슈 생성
- [x] 실행 보드 문서 생성
- [ ] 각 기능 PR에서 `Closes #N` 연결

## 참고
- Roadmap: `docs/roadmap-v1.5.md`
