### PR TITLE
[v1.5][P0-A] /doctor 레지스트리 건강검진 구현

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: osori
-description: "Osori v1.4.0 — Local project registry & context loader with Telegram slash commands. Registry versioning + auto-migration + fingerprints view + root filters + root management commands. Find, switch, list, add/remove projects, check status. Triggers: work on X, find project X, list projects, project status, project switch. | 오소리 — 텔레그램 슬래시 명령어 지원 로컬 프로젝트 레지스트리."
+description: "Osori v1.5.0-rc1 — Local project registry & context loader with Telegram slash commands. Registry versioning + auto-migration + fingerprints view + root filters + root management + doctor health checks. Find, switch, list, add/remove projects, check status. Triggers: work on X, find project X, list projects, project status, project switch. | 오소리 — 텔레그램 슬래시 명령어 지원 로컬 프로젝트 레지스트리."
 ---
 
 # Osori (오소리)
@@ -17,7 +17,7 @@ Local project registry & context loader for AI agents.
 - **python3** — Required. Used for JSON processing.
 - **git** — Project detection and status checks.
 
-## Telegram Bot Commands (Updated in v1.4.0)
+## Telegram Bot Commands (Updated in v1.5.0-rc1)
 
 Osori now supports Telegram slash commands for quick project management:
 
@@ -27,6 +27,7 @@ Osori now supports Telegram slash commands for quick project management:
 /find <name> [root|--root <root>] — Find a project by name (optional root scope)
 /switch <name> [root|--root <root>] — Switch to project and load context (optional root scope)
 /fingerprints [name] [--root <root>] — Show repo remote + last commit + open PR/issue counts
+/doctor [--fix] [--json] — Registry health check and safe auto-fix
 /list-roots — List roots, labels, paths, and project counts
 /root-add <key> [label] — Add root (or update label)
 /root-path-add <key> <path> — Add discovery path to root
@@ -49,6 +50,7 @@ status - Check project statuses (or by root)
 find - Find project by name
 switch - Switch to project
 fingerprints - Show repo/commit/PR/issue fingerprint
+doctor - Health check + safe auto-fix
 list-roots - Show roots and discovery paths
 root-add - Add root
 root-path-add - Add path to root
@@ -68,6 +70,7 @@ help - Show help
 /find agent-avengers work
 /switch Tesella --root personal
 /fingerprints Tesella --root personal
+/doctor --fix
 /list-roots
 /root-add work Work
 /root-path-add work /path/to/workspace
@@ -175,6 +178,21 @@ Telegram root filter:
 
 ```bash
 /status [root]
+```
+
+### Doctor
+Registry health check and optional safe fix.
+
+```bash
+/doctor
+/doctor --fix
+/doctor --json
+```
+
+Shell equivalent:
+
+```bash
+bash skills/osori/scripts/doctor.sh [--fix] [--json]
 ```
 
 ### Root Management

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+# Registry health checker for Osori
+# Usage: doctor.sh [--fix] [--json]
+
+set -euo pipefail
+
+REGISTRY_FILE="${OSORI_REGISTRY:-$HOME/.openclaw/osori.json}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DO_FIX="false"
+OUT_JSON="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fix)
+      DO_FIX="true"
+      shift
+      ;;
+    --json)
+      OUT_JSON="true"
+      shift
+      ;;
+    -h|--help|help)
+      cat << 'EOF'
+Usage:
+  doctor.sh [--fix] [--json]
+
+Options:
+  --fix   Apply safe automatic fixes (migration + exact duplicate removal)
+  --json  Print machine-readable JSON report
+EOF
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+OSORI_SCRIPT_DIR="$SCRIPT_DIR" \
+OSORI_REG="$REGISTRY_FILE" \
+OSORI_DO_FIX="$DO_FIX" \
+OSORI_OUT_JSON="$OUT_JSON" \
+python3 << 'PYEOF'
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+
+sys.path.insert(0, os.environ["OSORI_SCRIPT_DIR"])
+from registry_lib import (
+    REGISTRY_SCHEMA,
+    REGISTRY_VERSION,
+    load_registry,
+    registry_projects,
+    registry_roots,
+    save_registry,
+    set_registry_projects,
+)
+
+reg_path = os.environ["OSORI_REG"]
+do_fix = os.environ.get("OSORI_DO_FIX", "false").lower() == "true"
+out_json = os.environ.get("OSORI_OUT_JSON", "false").lower() == "true"
+
+findings = []
+
+
+def add(severity, code, message, suggestion=None, project=None):
+    row = {
+        "severity": severity,
+        "code": code,
+        "message": message,
+    }
+    if suggestion:
+        row["suggestion"] = suggestion
+    if project:
+        row["project"] = project
+    findings.append(row)
+
+
+def count_by_severity(rows):
+    c = {"error": 0, "warn": 0, "info": 0}
+    for r in rows:
+        sev = r.get("severity", "info")
+        if sev not in c:
+            c[sev] = 0
+        c[sev] += 1
+    return c
+
+
+def repo_valid(repo):
+    if repo == "":
+        return True
+    return re.match(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", repo) is not None
+
+
+raw_payload = None
+raw_ok = False
+if os.path.exists(reg_path):
+    try:
+        with open(reg_path, encoding="utf-8") as f:
+            raw_payload = json.load(f)
+            raw_ok = True
+    except Exception as e:
+        add(
+            "error",
+            "registry.corrupted",
+            f"Registry JSON parse failed: {e}",
+            "Run with --fix to preserve broken file and reinitialize safely.",
+        )
+else:
+    add("warn", "registry.missing", f"Registry file not found: {reg_path}", "Run with --fix to initialize registry.")
+
+if raw_ok:
+    if isinstance(raw_payload, list):
+        add("warn", "registry.legacy_array", "Legacy array registry detected.", "Run with --fix to migrate to versioned schema.")
+        raw_projects = [p for p in raw_payload if isinstance(p, dict)]
+        raw_roots = [{"key": "default", "paths": []}]
+        schema = None
+        version = None
+    elif isinstance(raw_payload, dict):
+        schema = raw_payload.get("schema")
+        version = raw_payload.get("version")
+
+        if schema != REGISTRY_SCHEMA:
+            add(
+                "warn",
+                "registry.schema_mismatch",
+                f"schema={schema!r}, expected {REGISTRY_SCHEMA!r}",
+                "Run with --fix to normalize schema.",
+            )
+
+        try:
+            version_int = int(version)
+        except Exception:
+            version_int = None
+
+        if version_int != REGISTRY_VERSION:
+            add(
+                "warn",
+                "registry.version_mismatch",
+                f"version={version!r}, expected {REGISTRY_VERSION}",
+                "Run with --fix to migrate version.",
+            )
+
+        raw_projects = raw_payload.get("projects", [])
+        if not isinstance(raw_projects, list):
+            add(
+                "error",
+                "registry.projects_invalid_type",
+                f"projects field is {type(raw_projects).__name__}, expected list",
+                "Run with --fix to normalize projects container.",
+            )
+            raw_projects = []
+
+        raw_roots = raw_payload.get("roots", [])
+        if not isinstance(raw_roots, list):
+            add(
+                "warn",
+                "registry.roots_invalid_type",
+                f"roots field is {type(raw_roots).__name__}, expected list",
+                "Run with --fix to normalize roots container.",
+            )
+            raw_roots = []
+    else:
+        add(
+            "error",
+            "registry.invalid_top_level",
+            f"top-level JSON type is {type(raw_payload).__name__}, expected object/list",
+            "Run with --fix to reset registry format safely.",
+        )
+        raw_projects = []
+        raw_roots = []
+
+    # root key set for raw validation
+    root_keys = set()
+    for r in raw_roots:
+        if isinstance(r, dict):
+            key = str(r.get("key", "")).strip()
+            if key:
+                root_keys.add(key)
+
+    # raw project checks
+    name_map = defaultdict(list)
+    path_map = defaultdict(list)
+
+    for idx, p in enumerate(raw_projects):
+        if not isinstance(p, dict):
+            add("error", "project.invalid_item", f"projects[{idx}] is not an object", "Run with --fix to normalize registry entries.")
+            continue
+
+        name = str(p.get("name", "")).strip()
+        path = str(p.get("path", "")).strip()
+        root = str(p.get("root", "default") or "default").strip() or "default"
+        repo = str(p.get("repo", "") or "")
+
+        if not name or not path:
+            add(
+                "error",
+                "project.missing_required",
+                f"projects[{idx}] missing required fields name/path",
+                "Run with --fix to remove invalid project entries.",
+            )
+            continue
+
+        name_map[name].append(idx)
+        path_map[path].append(idx)
+
+        if root_keys and root not in root_keys:
+            add(
+                "warn",
+                "project.root_reference_missing",
+                f"project '{name}' references unknown root '{root}'",
+                "Run with --fix to add missing root metadata automatically.",
+                project=name,
+            )
+
+        if not repo_valid(repo):
+            add(
+                "warn",
+                "project.repo_invalid_format",
+                f"project '{name}' has invalid repo format: {repo!r}",
+                "Use owner/repo format (or leave empty).",
+                project=name,
+            )
+
+        if not os.path.exists(path):
+            add(
+                "error",
+                "project.path_missing",
+                f"project '{name}' path does not exist: {path}",
+                "Remove project or update to a valid path.",
+                project=name,
+            )
+
+    for n, idxs in name_map.items():
+        if len(idxs) > 1:
+            add(
+                "warn",
+                "project.duplicate_name",
+                f"duplicate project name '{n}' at indices {idxs}",
+                "Keep one canonical entry and remove duplicates.",
+                project=n,
+            )
+
+    for pth, idxs in path_map.items():
+        if len(idxs) > 1:
+            add(
+                "warn",
+                "project.duplicate_path",
+                f"duplicate project path '{pth}' at indices {idxs}",
+                "Keep one canonical entry and remove duplicates.",
+            )
+
+fix_applied = False
+fix_backup = None
+migration_backup = None
+migration_notes = []
+dedupe_removed = 0
+
+if do_fix:
+    loaded = load_registry(reg_path, auto_migrate=True, make_backup_on_migrate=True)
+    migration_notes = loaded.migration_notes if loaded.migrated else []
+    migration_backup = loaded.backup_path
+    registry = loaded.registry
+
+    # Safe fix: remove exact duplicate entries by (name, path)
+    projects = registry_projects(registry)
+    seen = set()
+    deduped = []
+    for p in projects:
+        key = (str(p.get("name", "")).strip(), str(p.get("path", "")).strip())
+        if key in seen:
+            dedupe_removed += 1
+            continue
+        seen.add(key)
+        deduped.append(p)
+
+    if dedupe_removed > 0:
+        set_registry_projects(registry, deduped)
+        fix_backup = save_registry(reg_path, registry, make_backup=True)
+
+    fix_applied = True
+
+    if migration_notes:
+        add("info", "fix.migration_applied", f"migration applied: {'; '.join(migration_notes)}")
+    if migration_backup:
+        add("info", "fix.migration_backup", f"migration backup: {migration_backup}")
+    if dedupe_removed > 0:
+        add("info", "fix.dedupe_applied", f"removed exact duplicate entries: {dedupe_removed}")
+        if fix_backup:
+            add("info", "fix.backup_created", f"backup created: {fix_backup}")
+    if not migration_notes and dedupe_removed == 0:
+        add("info", "fix.noop", "no safe fix changes were required")
+
+counts = count_by_severity(findings)
+status = "ok" if counts.get("error", 0) == 0 and counts.get("warn", 0) == 0 else "issues"
+
+report = {
+    "status": status,
+    "registry": reg_path,
+    "counts": counts,
+    "findings": findings,
+    "fix": {
+        "requested": do_fix,
+        "applied": fix_applied,
+        "migrationNotes": migration_notes,
+        "migrationBackup": migration_backup,
+        "dedupeRemoved": dedupe_removed,
+        "backup": fix_backup,
+    },
+}
+
+if out_json:
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    raise SystemExit(0)
+
+print("🩺 Osori Doctor")
+print(f"Registry: {reg_path}")
+print(f"Counts: ERROR={counts.get('error', 0)} WARN={counts.get('warn', 0)} INFO={counts.get('info', 0)}")
+print()
+
+if not findings:
+    print("✅ No issues found.")
+else:
+    order = {"error": 0, "warn": 1, "info": 2}
+    for row in sorted(findings, key=lambda r: (order.get(r.get("severity", "info"), 9), r.get("code", ""))):
+        sev = row["severity"].upper()
+        print(f"[{sev}] {row['code']}: {row['message']}")
+        if row.get("project"):
+            print(f"  ↳ project: {row['project']}")
+        if row.get("suggestion"):
+            print(f"  ↳ fix: {row['suggestion']}")
+
+if do_fix:
+    print()
+    print("🔧 Fix mode executed.")
+PYEOF

--- a/scripts/telegram-commands.sh
+++ b/scripts/telegram-commands.sh
@@ -25,6 +25,7 @@ show_help() {
 /find <name> [root|--root <root>] — Find a project path (optional root scope)
 /switch <name> [root|--root <root>] — Switch to project & load context (optional root scope)
 /fingerprints [name] [--root <root>] — Show repo/commit/PR/issue fingerprints
+/doctor [--fix] [--json] — Registry health check and safe auto-fix
 /list-roots — List roots, labels, paths, project counts
 /root-add <key> [label] — Add/update root
 /root-path-add <key> <path> — Add discovery path to root
@@ -41,6 +42,7 @@ show_help() {
 `/find agent-avengers work`
 `/switch Tesella --root personal`
 `/fingerprints Tesella --root personal`
+`/doctor --fix`
 `/list-roots`
 `/root-add work Work`
 `/root-path-add work /path/to/workspace`
@@ -508,6 +510,10 @@ cmd_scan() {
     fi
 }
 
+cmd_doctor() {
+    bash "$SCRIPT_DIR/doctor.sh" "$@"
+}
+
 cmd_list_roots() {
     bash "$SCRIPT_DIR/root-manager.sh" list
 }
@@ -561,6 +567,7 @@ case "$command" in
     find) cmd_find "$@" ;;
     switch) cmd_switch "$@" ;;
     fingerprints) cmd_fingerprints "$@" ;;
+    doctor) cmd_doctor "$@" ;;
     list-roots|roots) cmd_list_roots ;;
     root-add) cmd_root_add "$@" ;;
     root-path-add) cmd_root_path_add "$@" ;;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -170,6 +170,144 @@ assert_eq "broken backup created" "1" "$broken_count"
 teardown_test
 
 echo ""
+echo "=== test_doctor_detects_basic_issues ==="
+setup_test
+# create missing path project + invalid repo format
+cat > "$TEST_TMP/osori.json" << JSONEOF
+{
+  "schema": "osori.registry",
+  "version": 2,
+  "updatedAt": "2026-02-16T00:00:00Z",
+  "roots": [{"key": "default", "label": "Default", "paths": []}],
+  "projects": [
+    {
+      "name": "bad-path",
+      "path": "$TEST_TMP/no-such-dir",
+      "repo": "invalid repo format",
+      "lang": "unknown",
+      "tags": [],
+      "description": "",
+      "addedAt": "2026-02-16",
+      "root": "default"
+    }
+  ]
+}
+JSONEOF
+out=$(bash "$PROJECT_ROOT/scripts/doctor.sh" 2>&1 || true)
+assert_contains "doctor detects missing path" "$out" "project.path_missing"
+assert_contains "doctor detects invalid repo" "$out" "project.repo_invalid_format"
+teardown_test
+
+echo ""
+echo "=== test_doctor_detects_duplicates ==="
+setup_test
+cat > "$TEST_TMP/osori.json" << JSONEOF
+{
+  "schema": "osori.registry",
+  "version": 2,
+  "updatedAt": "2026-02-16T00:00:00Z",
+  "roots": [{"key": "default", "label": "Default", "paths": []}],
+  "projects": [
+    {"name": "dup", "path": "$TEST_TMP/fake-project", "repo": "", "lang": "unknown", "tags": [], "description": "", "addedAt": "2026-02-16", "root": "default"},
+    {"name": "dup", "path": "$TEST_TMP/fake-project", "repo": "", "lang": "unknown", "tags": [], "description": "", "addedAt": "2026-02-16", "root": "default"}
+  ]
+}
+JSONEOF
+out=$(bash "$PROJECT_ROOT/scripts/doctor.sh" 2>&1 || true)
+assert_contains "doctor duplicate name" "$out" "project.duplicate_name"
+assert_contains "doctor duplicate path" "$out" "project.duplicate_path"
+teardown_test
+
+echo ""
+echo "=== test_doctor_detects_root_reference_missing ==="
+setup_test
+cat > "$TEST_TMP/osori.json" << JSONEOF
+{
+  "schema": "osori.registry",
+  "version": 2,
+  "updatedAt": "2026-02-16T00:00:00Z",
+  "roots": [{"key": "default", "label": "Default", "paths": []}],
+  "projects": [
+    {"name": "x", "path": "$TEST_TMP/fake-project", "repo": "", "lang": "unknown", "tags": [], "description": "", "addedAt": "2026-02-16", "root": "work"}
+  ]
+}
+JSONEOF
+out=$(bash "$PROJECT_ROOT/scripts/doctor.sh" 2>&1 || true)
+assert_contains "doctor root mismatch" "$out" "project.root_reference_missing"
+teardown_test
+
+echo ""
+echo "=== test_doctor_json_output ==="
+setup_test
+out_json=$(bash "$PROJECT_ROOT/scripts/doctor.sh" --json 2>&1)
+assert_contains "doctor json has status" "$out_json" '"status"'
+assert_contains "doctor json has counts" "$out_json" '"counts"'
+assert_contains "doctor json has findings" "$out_json" '"findings"'
+teardown_test
+
+echo ""
+echo "=== test_doctor_fix_legacy_migration ==="
+setup_test
+cat > "$TEST_TMP/osori.json" << 'JSONEOF'
+[
+  {
+    "name": "legacy-proj",
+    "path": "/tmp/legacy",
+    "repo": "",
+    "lang": "unknown",
+    "tags": [],
+    "description": "",
+    "addedAt": "2026-02-10"
+  }
+]
+JSONEOF
+out=$(bash "$PROJECT_ROOT/scripts/doctor.sh" --fix 2>&1)
+assert_contains "doctor fix migration info" "$out" "fix.migration_applied"
+content=$(cat "$TEST_TMP/osori.json")
+assert_contains "doctor fix migrated schema" "$content" '"schema": "osori.registry"'
+teardown_test
+
+echo ""
+echo "=== test_doctor_fix_dedupe ==="
+setup_test
+cat > "$TEST_TMP/osori.json" << JSONEOF
+{
+  "schema": "osori.registry",
+  "version": 2,
+  "updatedAt": "2026-02-16T00:00:00Z",
+  "roots": [{"key": "default", "label": "Default", "paths": []}],
+  "projects": [
+    {"name": "dup", "path": "$TEST_TMP/fake-project", "repo": "", "lang": "unknown", "tags": [], "description": "", "addedAt": "2026-02-16", "root": "default"},
+    {"name": "dup", "path": "$TEST_TMP/fake-project", "repo": "", "lang": "unknown", "tags": [], "description": "", "addedAt": "2026-02-16", "root": "default"}
+  ]
+}
+JSONEOF
+out=$(bash "$PROJECT_ROOT/scripts/doctor.sh" --fix 2>&1)
+assert_contains "doctor fix dedupe message" "$out" "fix.dedupe_applied"
+count=$(project_count "$TEST_TMP/osori.json")
+assert_eq "doctor fix removed duplicate" "1" "$count"
+teardown_test
+
+echo ""
+echo "=== test_doctor_fix_corrupted_registry ==="
+setup_test
+printf '{ broken json' > "$TEST_TMP/osori.json"
+out=$(bash "$PROJECT_ROOT/scripts/doctor.sh" --fix 2>&1)
+assert_contains "doctor corrupted detected" "$out" "registry.corrupted"
+count=$(project_count "$TEST_TMP/osori.json")
+assert_eq "doctor fix reinitialized registry" "0" "$count"
+broken_count=$(find "$TEST_TMP" -name 'osori.json.broken-*' | wc -l | tr -d ' ')
+assert_eq "doctor fix saved broken backup" "1" "$broken_count"
+teardown_test
+
+echo ""
+echo "=== test_telegram_doctor_command ==="
+setup_test
+doctor_out=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" doctor --json 2>&1)
+assert_contains "telegram doctor returns json" "$doctor_out" '"status"'
+teardown_test
+
+echo ""
 echo "=== test_fingerprints_view ==="
 setup_test
 git -C "$TEST_TMP/fake-project" remote add origin "https://github.com/example/osori-test.git"


### PR DESCRIPTION
## 요약
v1.5 P0-A 이슈에 해당하는 `/doctor` 명령을 추가했습니다.

## 변경 내용
- `scripts/doctor.sh` 신규 추가
  - 검사 항목:
    - path 미존재
    - 중복 project name/path
    - root 참조 불일치
    - repo 포맷 이상
    - schema/version 이상
    - 레지스트리 손상(JSON 파싱 실패)
  - 출력:
    - severity count(error/warn/info)
    - 항목별 코드/메시지/수정 제안
  - 옵션:
    - `--fix`: 안전 자동 수정(마이그레이션 + exact duplicate 제거)
    - `--json`: 기계 파싱 가능한 JSON 보고서
- `scripts/telegram-commands.sh`
  - `/doctor [--fix] [--json]` 명령 연결
  - help 텍스트 업데이트
- `SKILL.md`
  - doctor 명령/예시/설명 반영 (v1.5.0-rc1 표기)
- `tests/run_tests.sh`
  - doctor 관련 테스트 8개 이상 추가

## 테스트
- `./tests/run_tests.sh`
- 결과: 90 passed, 0 failed

## 이슈 연결
Closes #8
Related: #13
