### PR TITLE
[v1.5][P0-B] /root-remove 안전 삭제 규칙 구현

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: osori
-description: "Osori v1.5.0-rc1 — Local project registry & context loader with Telegram slash commands. Registry versioning + auto-migration + fingerprints view + root filters + root management + doctor health checks. Find, switch, list, add/remove projects, check status. Triggers: work on X, find project X, list projects, project status, project switch. | 오소리 — 텔레그램 슬래시 명령어 지원 로컬 프로젝트 레지스트리."
+description: "Osori v1.5.0-rc1 — Local project registry & context loader with Telegram slash commands. Registry versioning + auto-migration + fingerprints view + root filters + root management + doctor health checks + safe root remove. Find, switch, list, add/remove projects, check status. Triggers: work on X, find project X, list projects, project status, project switch. | 오소리 — 텔레그램 슬래시 명령어 지원 로컬 프로젝트 레지스트리."
 ---
 
 # Osori (오소리)
@@ -33,6 +33,7 @@ Osori now supports Telegram slash commands for quick project management:
 /root-path-add <key> <path> — Add discovery path to root
 /root-path-remove <key> <path> — Remove discovery path from root
 /root-set-label <key> <label> — Update root label
+/root-remove <key> [--reassign <target>] [--force] — Safely remove root
 /add <path> — Add project to registry
 /remove <name> — Remove project from registry
 /scan <path> [root] — Scan directory for git projects, optional root key
@@ -56,6 +57,7 @@ root-add - Add root
 root-path-add - Add path to root
 root-path-remove - Remove path from root
 root-set-label - Rename root label
+root-remove - Safely remove root (with reassign/force options)
 add - Add project to registry
 remove - Remove project
 scan - Scan directory (optional root)
@@ -74,6 +76,7 @@ help - Show help
 /list-roots
 /root-add work Work
 /root-path-add work /path/to/workspace
+/root-remove work --reassign default
 /add /Volumes/disk/MyProject
 /scan /path/to/workspace work
 ```
@@ -203,6 +206,7 @@ bash skills/osori/scripts/doctor.sh [--fix] [--json]
 /root-path-add <key> <path>
 /root-path-remove <key> <path>
 /root-set-label <key> <label>
+/root-remove <key> [--reassign <target>] [--force]
 ```
 
 Shell equivalents:
@@ -213,7 +217,14 @@ bash skills/osori/scripts/root-manager.sh add <key> [label]
 bash skills/osori/scripts/root-manager.sh path-add <key> <path>
 bash skills/osori/scripts/root-manager.sh path-remove <key> <path>
 bash skills/osori/scripts/root-manager.sh set-label <key> <label>
+bash skills/osori/scripts/root-manager.sh remove <key> [--reassign <target>] [--force]
 ```
+
+Safety rules for remove:
+- `default` root cannot be removed
+- if projects exist in root:
+  - `--reassign <target>` to move projects then remove
+  - or `--force` to move projects to `default` and remove
 
 ## Schema
 

--- a/scripts/root-manager.sh
+++ b/scripts/root-manager.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# Manage registry roots (list/add/path-add/path-remove/set-label)
+# Manage registry roots (list/add/path-add/path-remove/set-label/remove)
 # Usage:
 #   root-manager.sh list
 #   root-manager.sh add <root-key> [label]
 #   root-manager.sh path-add <root-key> <path>
 #   root-manager.sh path-remove <root-key> <path>
 #   root-manager.sh set-label <root-key> <label>
+#   root-manager.sh remove <root-key> [--reassign <target-root>] [--force]
 
 set -euo pipefail
 
@@ -25,6 +26,7 @@ Usage:
   root-manager.sh path-add <root-key> <path>
   root-manager.sh path-remove <root-key> <path>
   root-manager.sh set-label <root-key> <label>
+  root-manager.sh remove <root-key> [--reassign <target-root>] [--force]
 EOF
 }
 
@@ -250,6 +252,110 @@ for r in roots:
 
 print(f"❌ root not found: {key}")
 raise SystemExit(1)
+PYEOF
+    ;;
+
+  remove)
+    ROOT_KEY="${1:-}"
+    shift || true
+    REASSIGN_TARGET=""
+    FORCE="false"
+
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --reassign)
+          REASSIGN_TARGET="${2:-}"
+          shift 2
+          ;;
+        --force)
+          FORCE="true"
+          shift
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+
+    [[ -z "$ROOT_KEY" ]] && { usage; exit 1; }
+
+    OSORI_SCRIPT_DIR="$SCRIPT_DIR" \
+    OSORI_REG="$REGISTRY_FILE" \
+    OSORI_ROOT_KEY="$ROOT_KEY" \
+    OSORI_REASSIGN_TARGET="$REASSIGN_TARGET" \
+    OSORI_FORCE="$FORCE" \
+    python3 << 'PYEOF'
+import os
+import re
+import sys
+
+sys.path.insert(0, os.environ["OSORI_SCRIPT_DIR"])
+from registry_lib import load_registry, registry_projects, registry_roots, save_registry, set_registry_projects
+
+root_key = os.environ["OSORI_ROOT_KEY"].strip()
+reassign = os.environ.get("OSORI_REASSIGN_TARGET", "").strip()
+force = os.environ.get("OSORI_FORCE", "false").lower() == "true"
+
+if not re.match(r"^[A-Za-z0-9_-]+$", root_key):
+    print("❌ root key must match [A-Za-z0-9_-]+")
+    raise SystemExit(1)
+
+if root_key == "default":
+    print("❌ cannot remove protected root: default")
+    raise SystemExit(1)
+
+if reassign and reassign == root_key:
+    print("❌ --reassign target must be different from removed root")
+    raise SystemExit(1)
+
+res = load_registry(os.environ["OSORI_REG"], auto_migrate=True, make_backup_on_migrate=True)
+registry = res.registry
+roots = registry_roots(registry)
+projects = registry_projects(registry)
+
+root_keys = [r.get("key", "default") for r in roots]
+if root_key not in root_keys:
+    print(f"❌ root not found: {root_key}")
+    raise SystemExit(1)
+
+affected = [p for p in projects if str(p.get("root", "default") or "default") == root_key]
+affected_count = len(affected)
+
+if affected_count > 0 and not reassign and not force:
+    print(f"❌ root '{root_key}' has {affected_count} project(s); use --reassign <target-root> or --force")
+    raise SystemExit(1)
+
+target_root = None
+if reassign:
+    if reassign == "default":
+        target_root = "default"
+    else:
+        if reassign not in root_keys:
+            print(f"❌ reassign target root not found: {reassign}")
+            raise SystemExit(1)
+        target_root = reassign
+elif force and affected_count > 0:
+    target_root = "default"
+
+if target_root:
+    for p in projects:
+        if str(p.get("root", "default") or "default") == root_key:
+            p["root"] = target_root
+
+new_roots = [r for r in roots if r.get("key") != root_key]
+registry["roots"] = new_roots
+set_registry_projects(registry, projects)
+backup_path = save_registry(os.environ["OSORI_REG"], registry, make_backup=True)
+
+if target_root:
+    if force and not reassign:
+        print(f"⚠️ force mode: reassigned {affected_count} project(s) to 'default' before removing '{root_key}'")
+    else:
+        print(f"✅ reassigned {affected_count} project(s) from '{root_key}' to '{target_root}'")
+
+print(f"✅ removed root: {root_key}")
+if backup_path:
+    print(f"Backup: {backup_path}")
 PYEOF
     ;;
 

--- a/scripts/telegram-commands.sh
+++ b/scripts/telegram-commands.sh
@@ -31,6 +31,7 @@ show_help() {
 /root-path-add <key> <path> — Add discovery path to root
 /root-path-remove <key> <path> — Remove discovery path from root
 /root-set-label <key> <label> — Update root label
+/root-remove <key> [--reassign <target>] [--force] — Safely remove root
 /add <path> — Add project to registry
 /remove <name> — Remove project from registry
 /scan <path> [root] — Scan directory for projects (optional root key)
@@ -46,6 +47,7 @@ show_help() {
 `/list-roots`
 `/root-add work Work`
 `/root-path-add work /path/to/workspace`
+`/root-remove work --reassign default`
 `/scan /path/to/workspace work`
 EOF
 }
@@ -555,6 +557,15 @@ cmd_root_set_label() {
     bash "$SCRIPT_DIR/root-manager.sh" set-label "$key" "$label"
 }
 
+cmd_root_remove() {
+    local key="${1:-}"
+    shift || true
+
+    [[ -z "$key" ]] && { echo "❌ Usage: /root-remove <key> [--reassign <target>] [--force]"; exit 1; }
+
+    bash "$SCRIPT_DIR/root-manager.sh" remove "$key" "$@"
+}
+
 # Main dispatch
 command="${1:-help}"
 if [[ $# -gt 0 ]]; then
@@ -573,6 +584,7 @@ case "$command" in
     root-path-add) cmd_root_path_add "$@" ;;
     root-path-remove) cmd_root_path_remove "$@" ;;
     root-set-label) cmd_root_set_label "$@" ;;
+    root-remove) cmd_root_remove "$@" ;;
     add) cmd_add "${1:-}" ;;
     remove) cmd_remove "${1:-}" ;;
     scan) cmd_scan "${1:-}" "${2:-}" ;;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -406,6 +406,23 @@ assert_contains "root-manager remove path" "$path_remove_out" "Removed path from
 
 list2=$(bash "$PROJECT_ROOT/scripts/root-manager.sh" list 2>&1)
 assert_not_contains "root-manager path removed from list" "$list2" "$TEST_TMP/root-work"
+
+remove_default_out=$(bash "$PROJECT_ROOT/scripts/root-manager.sh" remove default 2>&1 || true)
+assert_contains "root-manager blocks default remove" "$remove_default_out" "cannot remove protected root: default"
+
+export OSORI_ROOT_KEY="work"
+bash "$PROJECT_ROOT/scripts/add-project.sh" "$TEST_TMP/fake-project" --name "work-owned" >/dev/null 2>&1
+
+remove_block_out=$(bash "$PROJECT_ROOT/scripts/root-manager.sh" remove work 2>&1 || true)
+assert_contains "root-manager blocks remove when projects exist" "$remove_block_out" "has 1 project(s)"
+
+remove_reassign_out=$(bash "$PROJECT_ROOT/scripts/root-manager.sh" remove work --reassign default 2>&1)
+assert_contains "root-manager reassign then remove" "$remove_reassign_out" "reassigned 1 project(s)"
+assert_contains "root-manager removed root after reassign" "$remove_reassign_out" "removed root: work"
+
+post_remove=$(cat "$TEST_TMP/osori.json")
+assert_not_contains "root-manager removed root from registry" "$post_remove" '"key": "work"'
+assert_contains "root-manager project reassigned to default" "$post_remove" '"root": "default"'
 teardown_test
 
 echo ""
@@ -433,8 +450,20 @@ assert_contains "telegram list-roots shows path" "$roots_after" "$TEST_TMP/tg-ro
 root_path_remove_out=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" root-path-remove work "$TEST_TMP/tg-root-path" 2>&1)
 assert_contains "telegram root-path-remove works" "$root_path_remove_out" "Removed path from root 'work'"
 
+# remove safety via telegram wrapper
+export OSORI_ROOT_KEY="work"
+bash "$PROJECT_ROOT/scripts/add-project.sh" "$TEST_TMP/fake-project" --name "tg-work-owned" >/dev/null 2>&1
+
+root_remove_block=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" root-remove work 2>&1 || true)
+assert_contains "telegram root-remove blocks when projects exist" "$root_remove_block" "has 1 project(s)"
+
+root_remove_force=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" root-remove work --force 2>&1)
+assert_contains "telegram root-remove force message" "$root_remove_force" "force mode"
+assert_contains "telegram root-remove force removed" "$root_remove_force" "removed root: work"
+
 roots_final=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" list-roots 2>&1)
 assert_not_contains "telegram list-roots path removed" "$roots_final" "$TEST_TMP/tg-root-path"
+assert_not_contains "telegram list-roots removed root hidden" "$roots_final" "work"
 teardown_test
 
 echo ""


### PR DESCRIPTION
## 요약
v1.5 P0-B 이슈에 해당하는 `/root-remove` 안전 삭제 기능을 추가했습니다.

## 변경 내용
- `scripts/root-manager.sh`
  - `remove <root-key> [--reassign <target-root>] [--force]` 명령 추가
  - 안전 규칙 구현:
    - `default` root 삭제 금지
    - 프로젝트가 남아있는 root는 기본 삭제 차단
    - `--reassign` 지정 시 대상 root로 이동 후 삭제
    - `--force` 지정 시 `default`로 이동 후 삭제
- `scripts/telegram-commands.sh`
  - `/root-remove <key> [--reassign <target>] [--force]` 커맨드 연결
  - help/examples 업데이트
- `SKILL.md`
  - root-remove 명령 문서화
  - 안전 규칙 설명 추가
- `tests/run_tests.sh`
  - root-remove 안전 규칙 테스트 추가
    - default 보호
    - project 존재 시 차단
    - reassign 후 삭제
    - telegram wrapper force 동작

## 테스트
- `./tests/run_tests.sh`
- 결과: 83 passed, 0 failed

## 이슈 연결
Closes #9
Related: #13
