### PR TITLE
[v1.5][P0-C] /switch 다중 매치 후보 선택 UX 개선

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -25,7 +25,7 @@ Osori now supports Telegram slash commands for quick project management:
 /list [root] — Show registered projects (optional root filter)
 /status [root] — Check status of projects (optional root filter)
 /find <name> [root|--root <root>] — Find a project by name (optional root scope)
-/switch <name> [root|--root <root>] — Switch to project and load context (optional root scope)
+/switch <name> [root|--root <root>] [--index <n>] — Switch to project and load context (multi-match selection)
 /fingerprints [name] [--root <root>] — Show repo remote + last commit + open PR/issue counts
 /list-roots — List roots, labels, paths, and project counts
 /root-add <key> [label] — Add root (or update label)
@@ -67,6 +67,7 @@ help - Show help
 /status personal
 /find agent-avengers work
 /switch Tesella --root personal
+/switch Tesella --root personal --index 1
 /fingerprints Tesella --root personal
 /list-roots
 /root-add work Work
@@ -118,21 +119,34 @@ Show all registered projects. Optional root filter supported in Telegram command
 (Example: `/list work`)
 
 ### Switch
-Supports optional root scope:
+Supports optional root scope and explicit candidate selection:
 
 ```bash
-/switch <name> [root|--root <root>]
+/switch <name> [root|--root <root>] [--index <n>]
 ```
 
 Flow:
-1. Search registry (fuzzy match, root-prioritized if provided)
-2. If not found → run "Finding Projects" flow above and suggest add path
-3. Load context:
+1. Search registry (fuzzy match, root-scoped if provided)
+2. If multiple matches:
+   - show candidate list (name/root/path/last commit/dirty/score)
+   - `--index <n>` to pick explicitly
+   - no index => auto-pick highest score
+3. If not found → run "Finding Projects" flow above and suggest add path
+4. Load context:
    - `git status --short`
    - `git branch --show-current`
    - `git log --oneline -5`
    - `gh issue list -R <repo> --limit 5` (when repo is set)
-4. Present summary
+5. Present summary
+
+Auto score policy:
+- +50 root exact (if root scope provided)
+- +30 name exact
+- +20 name prefix
+- +10 latest commit recency
+- -10 missing path
+- -5 repo missing
+- tie-break: latest commit, then name
 
 ### Fingerprints
 Show a one-shot project fingerprint view:

--- a/scripts/telegram-commands.sh
+++ b/scripts/telegram-commands.sh
@@ -23,7 +23,7 @@ show_help() {
 /list [root] — Show all projects (optionally filter by root)
 /status [root] — Check project statuses (optionally filter by root)
 /find <name> [root|--root <root>] — Find a project path (optional root scope)
-/switch <name> [root|--root <root>] — Switch to project & load context (optional root scope)
+/switch <name> [root|--root <root>] [--index <n>] — Switch to project & load context (multi-match selection)
 /fingerprints [name] [--root <root>] — Show repo/commit/PR/issue fingerprints
 /list-roots — List roots, labels, paths, project counts
 /root-add <key> [label] — Add/update root
@@ -40,6 +40,7 @@ show_help() {
 `/status personal`
 `/find agent-avengers work`
 `/switch Tesella --root personal`
+`/switch Tesella --root personal --index 1`
 `/fingerprints Tesella --root personal`
 `/list-roots`
 `/root-add work Work`
@@ -282,11 +283,16 @@ PYSCRIPT
 cmd_switch() {
     local name=""
     local root_filter=""
+    local index_arg=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --root)
                 root_filter="${2:-}"
+                shift 2
+                ;;
+            --index)
+                index_arg="${2:-}"
                 shift 2
                 ;;
             *)
@@ -300,9 +306,9 @@ cmd_switch() {
         esac
     done
 
-    [[ -z "$name" ]] && { echo "❌ Usage: /switch <project-name> [root|--root <root>]"; exit 1; }
+    [[ -z "$name" ]] && { echo "❌ Usage: /switch <project-name> [root|--root <root>] [--index <n>]"; exit 1; }
 
-    OSORI_NAME="$name" OSORI_ROOT_FILTER="$root_filter" OSORI_SCRIPT_DIR="$SCRIPT_DIR" OSORI_REG="$REGISTRY_FILE" python3 << 'PYSCRIPT'
+    OSORI_NAME="$name" OSORI_ROOT_FILTER="$root_filter" OSORI_SWITCH_INDEX="$index_arg" OSORI_SCRIPT_DIR="$SCRIPT_DIR" OSORI_REG="$REGISTRY_FILE" python3 << 'PYSCRIPT'
 import json
 import os
 import shutil
@@ -341,22 +347,66 @@ def gh_count(kind, repo):
         return "n/a"
 
 
+def git_last_commit(path):
+    rc_iso, iso, _ = run(["git", "-C", path, "log", "-1", "--format=%cI"])
+    rc_ts, ts, _ = run(["git", "-C", path, "log", "-1", "--format=%ct"])
+    if rc_iso != 0 or not iso:
+        iso = "n/a"
+    if rc_ts != 0 or not ts:
+        return iso, 0
+    try:
+        return iso, int(ts)
+    except Exception:
+        return iso, 0
+
+
+def git_dirty(path):
+    rc, out, _ = run(["git", "-C", path, "status", "--short"])
+    if rc != 0:
+        return "n/a"
+    return "dirty" if bool(out.strip()) else "clean"
+
+
 name_raw = os.environ["OSORI_NAME"].strip()
 name = name_raw.lower()
 root_filter = os.environ.get("OSORI_ROOT_FILTER", "").strip()
+index_arg = os.environ.get("OSORI_SWITCH_INDEX", "").strip()
 root_key = normalize_root_key(root_filter)
 
 res = load_registry(os.environ["OSORI_REG"], auto_migrate=True, make_backup_on_migrate=True)
 projects = filter_projects(registry_projects(res.registry), root_key=root_filter)
 roots = [r.get("key", "default") for r in registry_roots(res.registry)]
 
-target = None
+candidates = []
 for p in projects:
-    if name in p.get('name', '').lower():
-        target = p
-        break
+    pname = str(p.get("name", ""))
+    if name not in pname.lower():
+        continue
 
-if not target:
+    ppath = str(p.get("path", ""))
+    exists = bool(ppath) and os.path.exists(ppath)
+    commit_iso = "n/a"
+    commit_ts = 0
+    dirty = "n/a"
+
+    if exists:
+        commit_iso, commit_ts = git_last_commit(ppath)
+        dirty = git_dirty(ppath)
+
+    candidates.append({
+        "project": p,
+        "name": pname,
+        "root": str(p.get("root", "default") or "default"),
+        "path": ppath,
+        "exists": exists,
+        "repo": str(p.get("repo", "") or ""),
+        "commit_iso": commit_iso,
+        "commit_ts": commit_ts,
+        "dirty": dirty,
+        "score": 0,
+    })
+
+if not candidates:
     if root_key:
         print(f"❌ Project '{name_raw}' not found in root '{root_key}' registry.")
     else:
@@ -391,7 +441,60 @@ if not target:
 
     raise SystemExit(1)
 
-path = target.get('path', '')
+# Score policy (roadmap fixed)
+max_commit_ts = max((c["commit_ts"] for c in candidates), default=0)
+for c in candidates:
+    score = 0
+    nlow = c["name"].lower()
+
+    if root_key and c["root"] == root_key:
+        score += 50
+    if nlow == name:
+        score += 30
+    if nlow.startswith(name):
+        score += 20
+    if max_commit_ts > 0 and c["commit_ts"] == max_commit_ts:
+        score += 10
+    if not c["exists"]:
+        score -= 10
+    if not c["repo"]:
+        score -= 5
+
+    c["score"] = score
+
+candidates.sort(key=lambda c: (-c["score"], -c["commit_ts"], c["name"].lower()))
+
+if len(candidates) > 1:
+    print(f"🔎 Multiple matches ({len(candidates)}):")
+    for idx, c in enumerate(candidates, 1):
+        print(
+            f"  {idx}. {c['name']} [{c['root']}] | score={c['score']} | "
+            f"dirty={c['dirty']} | last={c['commit_iso']}"
+        )
+    print()
+
+selected = None
+if index_arg:
+    try:
+        index_val = int(index_arg)
+    except Exception:
+        print(f"❌ invalid --index value: {index_arg!r}")
+        raise SystemExit(1)
+
+    if index_val < 1 or index_val > len(candidates):
+        print(f"❌ --index out of range: {index_val} (1..{len(candidates)})")
+        raise SystemExit(1)
+
+    selected = candidates[index_val - 1]
+    if len(candidates) > 1:
+        print(f"✅ Selected candidate #{index_val} explicitly.\n")
+else:
+    selected = candidates[0]
+    if len(candidates) > 1:
+        print("🤖 Auto-selected #1 by score policy. Use --index <n> to choose explicitly.\n")
+
+target = selected["project"]
+path = selected["path"]
 if not path or not os.path.exists(path):
     print(f"⚠️ Path does not exist: {path}")
     raise SystemExit(1)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -300,6 +300,47 @@ assert_not_contains "telegram list-roots path removed" "$roots_final" "$TEST_TMP
 teardown_test
 
 echo ""
+echo "=== test_switch_multimatch_auto_and_index ==="
+setup_test
+
+mkdir -p "$TEST_TMP/mm-demo" "$TEST_TMP/mm-demo-app"
+for p in "$TEST_TMP/mm-demo" "$TEST_TMP/mm-demo-app"; do
+  git -C "$p" init -q 2>/dev/null
+  git -C "$p" config user.email "test@example.com"
+  git -C "$p" config user.name "osori-test"
+  echo "x" > "$p/README.md"
+  git -C "$p" add README.md >/dev/null 2>&1
+  GIT_AUTHOR_DATE="2026-02-15T10:00:00" GIT_COMMITTER_DATE="2026-02-15T10:00:00" git -C "$p" commit -m "init" >/dev/null 2>&1 || true
+done
+
+cat > "$TEST_TMP/osori.json" << JSONEOF
+{
+  "schema": "osori.registry",
+  "version": 2,
+  "updatedAt": "2026-02-16T00:00:00Z",
+  "roots": [{"key": "default", "label": "Default", "paths": []}],
+  "projects": [
+    {"name": "demo", "path": "$TEST_TMP/mm-demo", "repo": "", "lang": "unknown", "tags": [], "description": "", "addedAt": "2026-02-16", "root": "default"},
+    {"name": "demo-app", "path": "$TEST_TMP/mm-demo-app", "repo": "", "lang": "unknown", "tags": [], "description": "", "addedAt": "2026-02-16", "root": "default"},
+    {"name": "demo-missing", "path": "$TEST_TMP/no-such-dir", "repo": "", "lang": "unknown", "tags": [], "description": "", "addedAt": "2026-02-16", "root": "default"}
+  ]
+}
+JSONEOF
+
+auto_out=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" switch demo 2>&1)
+assert_contains "switch shows multiple candidates" "$auto_out" "Multiple matches (3)"
+assert_contains "switch auto-select message" "$auto_out" "Auto-selected #1"
+assert_contains "switch auto-select picks exact name" "$auto_out" "📁 *demo*"
+
+index_out=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" switch demo --index 2 2>&1)
+assert_contains "switch index selection message" "$index_out" "Selected candidate #2"
+assert_contains "switch index picks second candidate" "$index_out" "📁 *demo-app*"
+
+bad_index_out=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" switch demo --index 9 2>&1 || true)
+assert_contains "switch index out-of-range" "$bad_index_out" "--index out of range"
+teardown_test
+
+echo ""
 echo "=== test_switch_root_filter ==="
 setup_test
 export OSORI_ROOT_KEY="work"


### PR DESCRIPTION
## 요약
v1.5 P0-C 이슈에 해당하는 `/switch` 다중 매치 선택 UX를 구현했습니다.

## 변경 내용
- `scripts/telegram-commands.sh`
  - `/switch <name> [root|--root <root>] [--index <n>]` 지원
  - 다중 후보 시 후보 목록 출력:
    - name, root, score, dirty, last commit
  - 선택 방식:
    - `--index <n>` 명시 선택
    - 미지정 시 score 정책으로 자동 선택
  - 범위 오류/입력 오류 메시지 강화
- score 정책 반영
  - +50 root exact (root scope provided)
  - +30 name exact
  - +20 name prefix
  - +10 latest commit recency
  - -10 missing path
  - -5 missing repo
  - tie-break: latest commit, then name
- `SKILL.md`
  - switch 문법/예시/정책 문서화
- `tests/run_tests.sh`
  - 다중 후보(3개 이상) 시나리오 테스트 추가
  - auto-select / index-select / index out-of-range 검증

## 테스트
- `./tests/run_tests.sh`
- 결과: 79 passed, 0 failed

## 이슈 연결
Closes #10
Related: #13
