### PR TITLE
[v1.5][P1-E] Alias/Favorite 프로젝트 단축 관리

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: osori
-description: "Osori v1.5.0-rc1 — Local project registry & context loader with Telegram slash commands. Registry versioning + auto-migration + fingerprints view + root filters + root management + doctor health checks + safe root remove + GitHub count cache. Find, switch, list, add/remove projects, check status. Triggers: work on X, find project X, list projects, project status, project switch. | 오소리 — 텔레그램 슬래시 명령어 지원 로컬 프로젝트 레지스트리."
+description: "Osori v1.5.0 — Local project registry & context loader with Telegram slash commands. Registry versioning + auto-migration + root filters + root management + doctor + safe root remove + switch multi-match + GitHub count cache + alias/favorite commands. Find, switch, list, add/remove projects, check status. Triggers: work on X, find project X, list projects, project status, project switch. | 오소리 — 텔레그램 슬래시 명령어 지원 로컬 프로젝트 레지스트리."
 ---
 
 # Osori (오소리)
@@ -17,7 +17,7 @@ Local project registry & context loader for AI agents.
 - **python3** — Required. Used for JSON processing.
 - **git** — Project detection and status checks.
 
-## Telegram Bot Commands (Updated in v1.5.0-rc1)
+## Telegram Bot Commands (Updated in v1.5.0)
 
 Osori now supports Telegram slash commands for quick project management:
 
@@ -34,6 +34,11 @@ Osori now supports Telegram slash commands for quick project management:
 /root-path-remove <key> <path> — Remove discovery path from root
 /root-set-label <key> <label> — Update root label
 /root-remove <key> [--reassign <target>] [--force] — Safely remove root
+/alias-add <alias> <project> — Add alias for project
+/alias-remove <alias> — Remove alias
+/favorites — Show favorite projects
+/favorite-add <project> — Mark project as favorite
+/favorite-remove <project> — Unmark favorite
 /add <path> — Add project to registry
 /remove <name> — Remove project from registry
 /scan <path> [root] — Scan directory for git projects, optional root key
@@ -58,6 +63,11 @@ root-path-add - Add path to root
 root-path-remove - Remove path from root
 root-set-label - Rename root label
 root-remove - Safely remove root (with reassign/force options)
+alias-add - Add alias for a project
+alias-remove - Remove alias
+favorites - Show favorite projects
+favorite-add - Mark favorite project
+favorite-remove - Unmark favorite project
 add - Add project to registry
 remove - Remove project
 scan - Scan directory (optional root)
@@ -78,6 +88,9 @@ help - Show help
 /root-add work Work
 /root-path-add work /path/to/workspace
 /root-remove work --reassign default
+/alias-add rh RunnersHeart
+/favorite-add RunnersHeart
+/favorites
 /add /Volumes/disk/MyProject
 /scan /path/to/workspace work
 ```
@@ -88,13 +101,17 @@ help - Show help
 
 Override with the `OSORI_REGISTRY` environment variable.
 
-### Versioning & Migration (v1.4.1)
+### Versioning & Migration (v1.5.0)
 
 - Current schema: `osori.registry`
 - Current version: `2`
 - On every load, Osori auto-migrates older registry formats:
   - legacy array (`[]`) → versioned object
   - object without `schema/version` → normalized versioned object
+- Normalized registry fields:
+  - top-level `roots[]`
+  - top-level `aliases{}` (alias → project name)
+  - each `projects[]` item includes `favorite: bool`
 - Migration safety:
   - creates backup: `osori.json.bak-<timestamp>`
   - corrupted JSON is preserved as: `osori.json.broken-<timestamp>`
@@ -247,6 +264,29 @@ Safety rules for remove:
   - `--reassign <target>` to move projects then remove
   - or `--force` to move projects to `default` and remove
 
+### Alias & Favorites
+
+```bash
+/alias-add <alias> <project>
+/alias-remove <alias>
+/favorites
+/favorite-add <project>
+/favorite-remove <project>
+```
+
+Shell equivalents:
+
+```bash
+bash skills/osori/scripts/alias-favorite-manager.sh alias-add <alias> <project>
+bash skills/osori/scripts/alias-favorite-manager.sh alias-remove <alias>
+bash skills/osori/scripts/alias-favorite-manager.sh aliases
+bash skills/osori/scripts/alias-favorite-manager.sh favorite-add <project>
+bash skills/osori/scripts/alias-favorite-manager.sh favorite-remove <project>
+bash skills/osori/scripts/alias-favorite-manager.sh favorites
+```
+
+Aliases are case-insensitive and are resolved by `/find`, `/switch`, and `project-fingerprints.sh` name queries.
+
 ## Schema
 
 ```json
@@ -261,6 +301,9 @@ Safety rules for remove:
       "paths": []
     }
   ],
+  "aliases": {
+    "rh": "RunnersHeart"
+  },
   "projects": [
     {
       "name": "string",
@@ -270,7 +313,8 @@ Safety rules for remove:
       "tags": ["personal", "ios"],
       "description": "Short description",
       "addedAt": "YYYY-MM-DD",
-      "root": "default"
+      "root": "default",
+      "favorite": false
     }
   ]
 }

--- a/scripts/alias-favorite-manager.sh
+++ b/scripts/alias-favorite-manager.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Manage aliases and favorites in osori registry
+# Usage:
+#   alias-favorite-manager.sh alias-add <alias> <project>
+#   alias-favorite-manager.sh alias-remove <alias>
+#   alias-favorite-manager.sh aliases
+#   alias-favorite-manager.sh favorite-add <project-or-alias>
+#   alias-favorite-manager.sh favorite-remove <project-or-alias>
+#   alias-favorite-manager.sh favorites
+
+set -euo pipefail
+
+COMMAND="${1:-}"
+if [[ $# -gt 0 ]]; then
+  shift
+fi
+
+REGISTRY_FILE="${OSORI_REGISTRY:-$HOME/.openclaw/osori.json}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat << 'EOF'
+Usage:
+  alias-favorite-manager.sh alias-add <alias> <project>
+  alias-favorite-manager.sh alias-remove <alias>
+  alias-favorite-manager.sh aliases
+  alias-favorite-manager.sh favorite-add <project-or-alias>
+  alias-favorite-manager.sh favorite-remove <project-or-alias>
+  alias-favorite-manager.sh favorites
+EOF
+}
+
+case "$COMMAND" in
+  alias-add)
+    ALIAS_KEY="${1:-}"
+    PROJECT_QUERY="${2:-}"
+    [[ -z "$ALIAS_KEY" || -z "$PROJECT_QUERY" ]] && { usage; exit 1; }
+
+    OSORI_SCRIPT_DIR="$SCRIPT_DIR" OSORI_REG="$REGISTRY_FILE" OSORI_ALIAS="$ALIAS_KEY" OSORI_QUERY="$PROJECT_QUERY" python3 << 'PYEOF'
+import os
+import re
+import sys
+
+sys.path.insert(0, os.environ["OSORI_SCRIPT_DIR"])
+from registry_lib import (
+    load_registry,
+    registry_aliases,
+    registry_projects,
+    save_registry,
+    set_registry_aliases,
+)
+
+alias_key = os.environ["OSORI_ALIAS"].strip().lower()
+query = os.environ["OSORI_QUERY"].strip().lower()
+
+if not re.match(r"^[A-Za-z0-9_-]+$", alias_key):
+    print("❌ alias must match [A-Za-z0-9_-]+")
+    raise SystemExit(1)
+
+res = load_registry(os.environ["OSORI_REG"], auto_migrate=True, make_backup_on_migrate=True)
+registry = res.registry
+projects = registry_projects(registry)
+
+matches = [p for p in projects if query == str(p.get("name", "")).lower()]
+if not matches:
+    matches = [p for p in projects if query in str(p.get("name", "")).lower()]
+
+if not matches:
+    print(f"❌ project not found: {os.environ['OSORI_QUERY']}")
+    raise SystemExit(1)
+if len(matches) > 1:
+    names = ", ".join(str(p.get("name", "")) for p in matches[:5])
+    print(f"❌ ambiguous project query: {os.environ['OSORI_QUERY']} ({names})")
+    raise SystemExit(1)
+
+target_name = str(matches[0].get("name", "")).strip()
+if not target_name:
+    print("❌ selected project has invalid name")
+    raise SystemExit(1)
+
+aliases = registry_aliases(registry)
+aliases[alias_key] = target_name
+set_registry_aliases(registry, aliases)
+backup_path = save_registry(os.environ["OSORI_REG"], registry, make_backup=True)
+
+print(f"✅ alias added: {alias_key} -> {target_name}")
+if backup_path:
+    print(f"Backup: {backup_path}")
+PYEOF
+    ;;
+
+  alias-remove)
+    ALIAS_KEY="${1:-}"
+    [[ -z "$ALIAS_KEY" ]] && { usage; exit 1; }
+
+    OSORI_SCRIPT_DIR="$SCRIPT_DIR" OSORI_REG="$REGISTRY_FILE" OSORI_ALIAS="$ALIAS_KEY" python3 << 'PYEOF'
+import os
+import sys
+
+sys.path.insert(0, os.environ["OSORI_SCRIPT_DIR"])
+from registry_lib import load_registry, registry_aliases, save_registry, set_registry_aliases
+
+alias_key = os.environ["OSORI_ALIAS"].strip().lower()
+res = load_registry(os.environ["OSORI_REG"], auto_migrate=True, make_backup_on_migrate=True)
+registry = res.registry
+aliases = registry_aliases(registry)
+
+if alias_key not in aliases:
+    print(f"❌ alias not found: {alias_key}")
+    raise SystemExit(1)
+
+removed = aliases.pop(alias_key)
+set_registry_aliases(registry, aliases)
+backup_path = save_registry(os.environ["OSORI_REG"], registry, make_backup=True)
+
+print(f"✅ alias removed: {alias_key} (was -> {removed})")
+if backup_path:
+    print(f"Backup: {backup_path}")
+PYEOF
+    ;;
+
+  aliases)
+    OSORI_SCRIPT_DIR="$SCRIPT_DIR" OSORI_REG="$REGISTRY_FILE" python3 << 'PYEOF'
+import os
+import sys
+
+sys.path.insert(0, os.environ["OSORI_SCRIPT_DIR"])
+from registry_lib import load_registry, registry_aliases
+
+res = load_registry(os.environ["OSORI_REG"], auto_migrate=True, make_backup_on_migrate=True)
+aliases = registry_aliases(res.registry)
+
+if not aliases:
+    print("📎 No aliases configured.")
+    raise SystemExit(0)
+
+print(f"📎 Aliases ({len(aliases)})")
+for k in sorted(aliases.keys()):
+    print(f"- {k} -> {aliases[k]}")
+PYEOF
+    ;;
+
+  favorite-add|favorite-remove)
+    PROJECT_QUERY="${1:-}"
+    [[ -z "$PROJECT_QUERY" ]] && { usage; exit 1; }
+
+    OSORI_SCRIPT_DIR="$SCRIPT_DIR" OSORI_REG="$REGISTRY_FILE" OSORI_QUERY="$PROJECT_QUERY" OSORI_COMMAND="$COMMAND" python3 << 'PYEOF'
+import os
+import sys
+
+sys.path.insert(0, os.environ["OSORI_SCRIPT_DIR"])
+from registry_lib import load_registry, registry_projects, resolve_alias, save_registry, set_registry_projects
+
+query_raw = os.environ["OSORI_QUERY"].strip()
+cmd = os.environ["OSORI_COMMAND"]
+mark_value = cmd == "favorite-add"
+
+res = load_registry(os.environ["OSORI_REG"], auto_migrate=True, make_backup_on_migrate=True)
+registry = res.registry
+projects = registry_projects(registry)
+query = resolve_alias(query_raw, registry).lower()
+
+matches = [p for p in projects if query == str(p.get("name", "")).lower()]
+if not matches:
+    matches = [p for p in projects if query in str(p.get("name", "")).lower()]
+
+if not matches:
+    print(f"❌ project not found: {query_raw}")
+    raise SystemExit(1)
+if len(matches) > 1:
+    names = ", ".join(str(p.get("name", "")) for p in matches[:5])
+    print(f"❌ ambiguous project query: {query_raw} ({names})")
+    raise SystemExit(1)
+
+target_name = str(matches[0].get("name", ""))
+changed = False
+for p in projects:
+    if str(p.get("name", "")) == target_name:
+        if bool(p.get("favorite", False)) != mark_value:
+            p["favorite"] = mark_value
+            changed = True
+        break
+
+if not changed:
+    state = "already favorite" if mark_value else "already not favorite"
+    print(f"ℹ️ {target_name}: {state}")
+    raise SystemExit(0)
+
+set_registry_projects(registry, projects)
+backup_path = save_registry(os.environ["OSORI_REG"], registry, make_backup=True)
+
+if mark_value:
+    print(f"⭐ favorite added: {target_name}")
+else:
+    print(f"✅ favorite removed: {target_name}")
+if backup_path:
+    print(f"Backup: {backup_path}")
+PYEOF
+    ;;
+
+  favorites)
+    OSORI_SCRIPT_DIR="$SCRIPT_DIR" OSORI_REG="$REGISTRY_FILE" python3 << 'PYEOF'
+import os
+import sys
+
+sys.path.insert(0, os.environ["OSORI_SCRIPT_DIR"])
+from registry_lib import load_registry, registry_projects
+
+res = load_registry(os.environ["OSORI_REG"], auto_migrate=True, make_backup_on_migrate=True)
+projects = registry_projects(res.registry)
+favs = [p for p in projects if bool(p.get("favorite", False))]
+
+if not favs:
+    print("⭐ No favorite projects.")
+    raise SystemExit(0)
+
+favs.sort(key=lambda p: str(p.get("name", "")).lower())
+print(f"⭐ Favorites ({len(favs)})")
+for p in favs:
+    name = p.get("name", "-")
+    root = p.get("root", "default")
+    path = p.get("path", "-")
+    print(f"- {name} [{root}] | {path}")
+PYEOF
+    ;;
+
+  -h|--help|help)
+    usage
+    ;;
+
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/scripts/project-fingerprints.sh
+++ b/scripts/project-fingerprints.sh
@@ -45,7 +45,7 @@ from typing import List
 
 sys.path.insert(0, os.environ["OSORI_SCRIPT_DIR"])
 from github_cache import DEFAULT_CACHE_PATH, get_open_count
-from registry_lib import filter_projects, load_registry, parse_repo_from_remote, registry_projects
+from registry_lib import filter_projects, load_registry, parse_repo_from_remote, registry_projects, resolve_alias
 
 
 def run(cmd: List[str], timeout: int = 8):
@@ -92,7 +92,8 @@ root_filter = os.environ.get("OSORI_ROOT_FILTER", "").strip()
 reg_file = os.environ["OSORI_REG"]
 
 loaded = load_registry(reg_file, auto_migrate=True, make_backup_on_migrate=True)
-projects = filter_projects(registry_projects(loaded.registry), root_key=root_filter, name_query=query)
+resolved_query = resolve_alias(query, loaded.registry) if query else query
+projects = filter_projects(registry_projects(loaded.registry), root_key=root_filter, name_query=resolved_query)
 
 if not projects:
     where = []
@@ -103,6 +104,10 @@ if not projects:
     suffix = f" ({', '.join(where)})" if where else ""
     print(f"📂 No matching projects{suffix}.")
     raise SystemExit(0)
+
+if query and resolved_query != query:
+    print(f"ℹ️ alias resolved: {query} -> {resolved_query}")
+    print()
 
 if loaded.migrated:
     notes = "; ".join(loaded.migration_notes)

--- a/scripts/registry_lib.py
+++ b/scripts/registry_lib.py
@@ -51,6 +51,7 @@ def _empty_registry() -> Dict[str, Any]:
         "updatedAt": _utc_now_iso(),
         "roots": _default_roots(),
         "projects": [],
+        "aliases": {},
     }
 
 
@@ -89,6 +90,7 @@ def normalize_project(item: Any) -> Dict[str, Any] | None:
         "description": str(item.get("description", "") or ""),
         "addedAt": str(item.get("addedAt") or _local_today()),
         "root": str(item.get("root", "default") or "default"),
+        "favorite": bool(item.get("favorite", False)),
     }
     return proj
 
@@ -168,6 +170,9 @@ def _migrate_object(payload: Dict[str, Any]) -> Tuple[Dict[str, Any], List[str]]
             reg["roots"].append({"key": proj_root, "label": proj_root.title(), "paths": []})
             root_keys.add(proj_root)
 
+    # normalize aliases
+    reg["aliases"] = registry_aliases(reg)
+
     if version < REGISTRY_VERSION:
         notes.append(f"version migration v{version} -> v{REGISTRY_VERSION}")
         reg["version"] = REGISTRY_VERSION
@@ -199,6 +204,7 @@ def save_registry(path: str, registry: Dict[str, Any], make_backup: bool = True)
     reg_copy.setdefault("version", REGISTRY_VERSION)
     reg_copy.setdefault("roots", _default_roots())
     reg_copy.setdefault("projects", [])
+    reg_copy.setdefault("aliases", {})
     reg_copy["updatedAt"] = _utc_now_iso()
 
     backup_path: str | None = None
@@ -295,6 +301,51 @@ def normalize_root_key(root_key: str | None) -> str | None:
     if key in {"all", "*"}:
         return None
     return key
+
+
+def _normalize_alias_key(alias: str | None) -> str:
+    if alias is None:
+        return ""
+    return str(alias).strip().lower()
+
+
+def registry_aliases(registry: Dict[str, Any]) -> Dict[str, str]:
+    raw = registry.get("aliases", {})
+    if not isinstance(raw, dict):
+        return {}
+
+    out: Dict[str, str] = {}
+    for k, v in raw.items():
+        key = _normalize_alias_key(str(k))
+        if not key:
+            continue
+        if not isinstance(v, str):
+            continue
+        target = v.strip()
+        if not target:
+            continue
+        out[key] = target
+    return out
+
+
+def set_registry_aliases(registry: Dict[str, Any], aliases: Dict[str, str]) -> None:
+    normalized = {}
+    for k, v in aliases.items():
+        key = _normalize_alias_key(k)
+        target = str(v).strip()
+        if not key or not target:
+            continue
+        normalized[key] = target
+    registry["aliases"] = normalized
+    registry["updatedAt"] = _utc_now_iso()
+
+
+def resolve_alias(name_or_alias: str, registry: Dict[str, Any]) -> str:
+    aliases = registry_aliases(registry)
+    key = _normalize_alias_key(name_or_alias)
+    if key in aliases:
+        return aliases[key]
+    return name_or_alias
 
 
 def parse_env_search_paths(paths_env: str | None) -> List[str]:

--- a/scripts/telegram-commands.sh
+++ b/scripts/telegram-commands.sh
@@ -32,6 +32,11 @@ show_help() {
 /root-path-remove <key> <path> — Remove discovery path from root
 /root-set-label <key> <label> — Update root label
 /root-remove <key> [--reassign <target>] [--force] — Safely remove root
+/alias-add <alias> <project> — Add alias for project
+/alias-remove <alias> — Remove alias
+/favorites — Show favorite projects
+/favorite-add <project> — Mark project as favorite
+/favorite-remove <project> — Unmark favorite
 /add <path> — Add project to registry
 /remove <name> — Remove project from registry
 /scan <path> [root] — Scan directory for projects (optional root key)
@@ -49,6 +54,8 @@ show_help() {
 `/root-add work Work`
 `/root-path-add work /path/to/workspace`
 `/root-remove work --reassign default`
+`/alias-add rh RunnersHeart`
+`/favorites`
 `/scan /path/to/workspace work`
 EOF
 }
@@ -193,6 +200,7 @@ from registry_lib import (
     normalize_root_key,
     registry_projects,
     registry_roots,
+    resolve_alias,
     search_paths_for_discovery,
 )
 
@@ -210,14 +218,18 @@ def within_any(path, roots):
 
 
 name = os.environ["OSORI_NAME"].strip()
-query = name.lower()
 root_filter = os.environ.get("OSORI_ROOT_FILTER", "").strip()
 
 res = load_registry(os.environ["OSORI_REG"], auto_migrate=True, make_backup_on_migrate=True)
+resolved_name = resolve_alias(name, res.registry)
+query = resolved_name.lower()
 projects = filter_projects(registry_projects(res.registry), root_key=root_filter)
 root_key = normalize_root_key(root_filter)
 roots_meta = registry_roots(res.registry)
 root_keys = [r.get("key", "default") for r in roots_meta]
+
+if resolved_name != name:
+    print(f"ℹ️ alias resolved: {name} -> {resolved_name}")
 
 # 1) Registry lookup (root-prioritized when root_filter is set)
 for p in projects:
@@ -246,7 +258,7 @@ search_paths = search_paths_for_discovery(
 
 # 2) Spotlight (macOS)
 if shutil.which('mdfind'):
-    r = subprocess.run(['mdfind', f'kMDItemFSName == "{name}"'], capture_output=True, text=True)
+    r = subprocess.run(['mdfind', f'kMDItemFSName == "{resolved_name}"'], capture_output=True, text=True)
     lines = [line for line in r.stdout.strip().split('\n') if line.strip()]
     if lines:
         if root_key:
@@ -328,6 +340,7 @@ from registry_lib import (
     parse_repo_from_remote,
     registry_projects,
     registry_roots,
+    resolve_alias,
     search_paths_for_discovery,
 )
 
@@ -391,14 +404,18 @@ def git_dirty(path):
 
 
 name_raw = os.environ["OSORI_NAME"].strip()
-name = name_raw.lower()
 root_filter = os.environ.get("OSORI_ROOT_FILTER", "").strip()
 index_arg = os.environ.get("OSORI_SWITCH_INDEX", "").strip()
 root_key = normalize_root_key(root_filter)
 
 res = load_registry(os.environ["OSORI_REG"], auto_migrate=True, make_backup_on_migrate=True)
+resolved_name = resolve_alias(name_raw, res.registry)
+name = resolved_name.lower()
 projects = filter_projects(registry_projects(res.registry), root_key=root_filter)
 roots = [r.get("key", "default") for r in registry_roots(res.registry)]
+
+if resolved_name != name_raw:
+    print(f"ℹ️ alias resolved: {name_raw} -> {resolved_name}")
 
 candidates = []
 for p in projects:
@@ -688,6 +705,35 @@ cmd_root_remove() {
     bash "$SCRIPT_DIR/root-manager.sh" remove "$key" "$@"
 }
 
+cmd_alias_add() {
+    local alias_key="${1:-}"
+    local project="${2:-}"
+    [[ -z "$alias_key" || -z "$project" ]] && { echo "❌ Usage: /alias-add <alias> <project>"; exit 1; }
+    bash "$SCRIPT_DIR/alias-favorite-manager.sh" alias-add "$alias_key" "$project"
+}
+
+cmd_alias_remove() {
+    local alias_key="${1:-}"
+    [[ -z "$alias_key" ]] && { echo "❌ Usage: /alias-remove <alias>"; exit 1; }
+    bash "$SCRIPT_DIR/alias-favorite-manager.sh" alias-remove "$alias_key"
+}
+
+cmd_favorites() {
+    bash "$SCRIPT_DIR/alias-favorite-manager.sh" favorites
+}
+
+cmd_favorite_add() {
+    local project="${1:-}"
+    [[ -z "$project" ]] && { echo "❌ Usage: /favorite-add <project>"; exit 1; }
+    bash "$SCRIPT_DIR/alias-favorite-manager.sh" favorite-add "$project"
+}
+
+cmd_favorite_remove() {
+    local project="${1:-}"
+    [[ -z "$project" ]] && { echo "❌ Usage: /favorite-remove <project>"; exit 1; }
+    bash "$SCRIPT_DIR/alias-favorite-manager.sh" favorite-remove "$project"
+}
+
 # Main dispatch
 command="${1:-help}"
 if [[ $# -gt 0 ]]; then
@@ -707,6 +753,11 @@ case "$command" in
     root-path-remove) cmd_root_path_remove "$@" ;;
     root-set-label) cmd_root_set_label "$@" ;;
     root-remove) cmd_root_remove "$@" ;;
+    alias-add) cmd_alias_add "${1:-}" "${2:-}" ;;
+    alias-remove) cmd_alias_remove "${1:-}" ;;
+    favorites) cmd_favorites ;;
+    favorite-add) cmd_favorite_add "${1:-}" ;;
+    favorite-remove) cmd_favorite_remove "${1:-}" ;;
     add) cmd_add "${1:-}" ;;
     remove) cmd_remove "${1:-}" ;;
     scan) cmd_scan "${1:-}" "${2:-}" ;;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -563,6 +563,49 @@ assert_contains "switch index out-of-range" "$bad_index_out" "--index out of ran
 teardown_test
 
 echo ""
+echo "=== test_alias_commands_and_resolution ==="
+setup_test
+
+# register project
+bash "$PROJECT_ROOT/scripts/add-project.sh" "$TEST_TMP/fake-project" --name "RunnersHeart" >/dev/null 2>&1
+
+alias_add_out=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" alias-add rh RunnersHeart 2>&1)
+assert_contains "alias-add works" "$alias_add_out" "alias added: rh -> RunnersHeart"
+
+aliases_out=$(bash "$PROJECT_ROOT/scripts/alias-favorite-manager.sh" aliases 2>&1)
+assert_contains "aliases list includes key" "$aliases_out" "rh -> RunnersHeart"
+
+find_alias_out=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" find rh 2>&1)
+assert_contains "find resolves alias" "$find_alias_out" "alias resolved: rh -> RunnersHeart"
+assert_contains "find alias returns project" "$find_alias_out" "RunnersHeart"
+
+fp_alias_out=$(bash "$PROJECT_ROOT/scripts/project-fingerprints.sh" rh 2>&1)
+assert_contains "fingerprints resolves alias" "$fp_alias_out" "alias resolved: rh -> RunnersHeart"
+
+alias_remove_out=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" alias-remove rh 2>&1)
+assert_contains "alias-remove works" "$alias_remove_out" "alias removed: rh"
+teardown_test
+
+echo ""
+echo "=== test_favorite_commands ==="
+setup_test
+
+bash "$PROJECT_ROOT/scripts/add-project.sh" "$TEST_TMP/fake-project" --name "FavProj" >/dev/null 2>&1
+
+fav_add_out=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" favorite-add FavProj 2>&1)
+assert_contains "favorite-add works" "$fav_add_out" "favorite added: FavProj"
+
+favs_out=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" favorites 2>&1)
+assert_contains "favorites list shows project" "$favs_out" "FavProj"
+
+fav_remove_out=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" favorite-remove FavProj 2>&1)
+assert_contains "favorite-remove works" "$fav_remove_out" "favorite removed: FavProj"
+
+favs_out2=$(bash "$PROJECT_ROOT/scripts/telegram-commands.sh" favorites 2>&1)
+assert_contains "favorites empty message" "$favs_out2" "No favorite projects"
+teardown_test
+
+echo ""
 echo "=== test_switch_root_filter ==="
 setup_test
 export OSORI_ROOT_KEY="work"


### PR DESCRIPTION
## Summary
- add registry-level alias map (`aliases`) normalization + helpers
- add project-level `favorite` normalization
- add new manager script: `scripts/alias-favorite-manager.sh`
  - `alias-add`, `alias-remove`, `aliases`
  - `favorite-add`, `favorite-remove`, `favorites`
- wire Telegram commands
  - `/alias-add`, `/alias-remove`, `/favorites`, `/favorite-add`, `/favorite-remove`
- apply alias resolution to `/find`, `/switch`, and `project-fingerprints.sh` query
- update `SKILL.md` docs/syntax/schema examples
- add tests for alias/favorite flows

## Test
- `./tests/run_tests.sh`
- Result: **84 passed, 0 failed**

Closes #12
Related #13
