### PR TITLE
feat: Entire CLI 통합 (osori 프로젝트 컨텍스트 실행)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,84 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code post-task"
+          }
+        ]
+      },
+      {
+        "matcher": "TodoWrite",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code post-todo"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code pre-task"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code session-end"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code session-start"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code stop"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code user-prompt-submit"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "deny": [
+      "Read(./.entire/metadata/**)"
+    ]
+  }
+}

--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,0 +1,4 @@
+tmp/
+settings.local.json
+metadata/
+logs/

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,0 +1,4 @@
+{
+  "strategy": "manual-commit",
+  "enabled": true
+}

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: osori
-description: "Osori v1.5.0 — Local project registry & context loader with Telegram slash commands. Registry versioning + auto-migration + root filters + root management + doctor + safe root remove + switch multi-match + GitHub count cache + alias/favorite commands. Find, switch, list, add/remove projects, check status. Triggers: work on X, find project X, list projects, project status, project switch. | 오소리 — 텔레그램 슬래시 명령어 지원 로컬 프로젝트 레지스트리."
+description: "Osori v1.5.0 — Local project registry & context loader with Telegram slash commands. Registry versioning + auto-migration + root filters + root management + doctor + safe root remove + switch multi-match + GitHub count cache + alias/favorite + Entire integration commands. Find, switch, list, add/remove projects, check status. Triggers: work on X, find project X, list projects, project status, project switch. | 오소리 — 텔레그램 슬래시 명령어 지원 로컬 프로젝트 레지스트리."
 ---
 
 # Osori (오소리)
@@ -11,11 +11,13 @@ Local project registry & context loader for AI agents.
 
 - **macOS**: `mdfind` (Spotlight, built-in), `python3`, `git`, `gh` CLI
 - **Linux**: `mdfind` unavailable → uses `find` as fallback automatically. `python3`, `git`, `gh` CLI required.
+- **Entire integration (optional)**: `entire` CLI installed (for `/entire-*` commands)
 
 ## Dependencies
 
 - **python3** — Required. Used for JSON processing.
 - **git** — Project detection and status checks.
+- **entire** — Optional. Required only for `/entire-status`, `/entire-enable`, `/entire-rewind-list`.
 
 ## Telegram Bot Commands (Updated in v1.5.0)
 
@@ -39,6 +41,9 @@ Osori now supports Telegram slash commands for quick project management:
 /favorites — Show favorite projects
 /favorite-add <project> — Mark project as favorite
 /favorite-remove <project> — Unmark favorite
+/entire-status <project> [root|--root <root>] — Show Entire status in a project
+/entire-enable <project> [root|--root <root>] [--agent <name>] [--strategy <name>] — Enable Entire in a project
+/entire-rewind-list <project> [root|--root <root>] — List rewind points in a project
 /add <path> — Add project to registry
 /remove <name> — Remove project from registry
 /scan <path> [root] — Scan directory for git projects, optional root key
@@ -68,6 +73,9 @@ alias-remove - Remove alias
 favorites - Show favorite projects
 favorite-add - Mark favorite project
 favorite-remove - Unmark favorite project
+entire-status - Show Entire status for a project
+entire-enable - Enable Entire for a project
+entire-rewind-list - List rewind points for a project
 add - Add project to registry
 remove - Remove project
 scan - Scan directory (optional root)
@@ -91,6 +99,8 @@ help - Show help
 /alias-add rh RunnersHeart
 /favorite-add RunnersHeart
 /favorites
+/entire-status osori
+/entire-enable osori --agent claude-code --strategy manual-commit
 /add /Volumes/disk/MyProject
 /scan /path/to/workspace work
 ```
@@ -286,6 +296,28 @@ bash skills/osori/scripts/alias-favorite-manager.sh favorites
 ```
 
 Aliases are case-insensitive and are resolved by `/find`, `/switch`, and `project-fingerprints.sh` name queries.
+
+### Entire Integration
+
+Run Entire CLI commands in a registered project context:
+
+```bash
+/entire-status <project> [root|--root <root>]
+/entire-enable <project> [root|--root <root>] [--agent <name>] [--strategy <name>]
+/entire-rewind-list <project> [root|--root <root>]
+```
+
+Shell equivalent:
+
+```bash
+bash skills/osori/scripts/entire-manager.sh status <project> [root|--root <root>]
+bash skills/osori/scripts/entire-manager.sh enable <project> [root|--root <root>] [entire enable flags...]
+bash skills/osori/scripts/entire-manager.sh rewind-list <project> [root|--root <root>]
+```
+
+Defaults:
+- `entire enable` defaults to `--agent claude-code --strategy manual-commit` when not provided.
+- `/entire-rewind-list` uses non-destructive JSON listing (`entire rewind --list`).
 
 ## Schema
 

--- a/scripts/entire-manager.sh
+++ b/scripts/entire-manager.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Manage Entire CLI per registered project
+# Usage:
+#   entire-manager.sh status <project> [root|--root <root>]
+#   entire-manager.sh enable <project> [root|--root <root>] [entire enable flags...]
+#   entire-manager.sh rewind-list <project> [root|--root <root>]
+
+set -euo pipefail
+
+COMMAND="${1:-}"
+if [[ $# -gt 0 ]]; then
+  shift
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REGISTRY_FILE="${OSORI_REGISTRY:-$HOME/.openclaw/osori.json}"
+
+PROJECT_QUERY=""
+ROOT_FILTER=""
+EXTRA_ARGS=()
+PROJECT_NAME=""
+PROJECT_PATH=""
+PROJECT_ROOT=""
+
+usage() {
+  cat << 'EOF'
+Usage:
+  entire-manager.sh status <project> [root|--root <root>]
+  entire-manager.sh enable <project> [root|--root <root>] [entire enable flags...]
+  entire-manager.sh rewind-list <project> [root|--root <root>]
+
+Examples:
+  entire-manager.sh status osori
+  entire-manager.sh enable osori --agent claude-code --strategy manual-commit
+  entire-manager.sh rewind-list osori --root work
+EOF
+}
+
+ensure_entire() {
+  if ! command -v entire >/dev/null 2>&1; then
+    echo "❌ 'entire' CLI not found. Install first: brew tap entireio/tap && brew install entireio/tap/entire"
+    exit 1
+  fi
+}
+
+parse_target_and_extra() {
+  PROJECT_QUERY=""
+  ROOT_FILTER=""
+  EXTRA_ARGS=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --root)
+        ROOT_FILTER="${2:-}"
+        if [[ -z "$ROOT_FILTER" ]]; then
+          echo "❌ --root requires a value"
+          exit 1
+        fi
+        shift 2
+        ;;
+      --agent|--strategy|--telemetry|--to)
+        if [[ $# -lt 2 ]]; then
+          echo "❌ $1 requires a value"
+          exit 1
+        fi
+        EXTRA_ARGS+=("$1" "$2")
+        shift 2
+        ;;
+      --agent=*|--strategy=*|--telemetry=*|--to=*)
+        EXTRA_ARGS+=("$1")
+        shift
+        ;;
+      --local|--project|--skip-push-sessions|--force|--logs-only|--reset)
+        EXTRA_ARGS+=("$1")
+        shift
+        ;;
+      *)
+        if [[ -z "$PROJECT_QUERY" ]]; then
+          PROJECT_QUERY="$1"
+        elif [[ -z "$ROOT_FILTER" ]]; then
+          ROOT_FILTER="$1"
+        else
+          EXTRA_ARGS+=("$1")
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  if [[ -z "$PROJECT_QUERY" ]]; then
+    echo "❌ project query is required"
+    exit 1
+  fi
+}
+
+resolve_project() {
+  local resolved
+  resolved=$(OSORI_SCRIPT_DIR="$SCRIPT_DIR" OSORI_REG="$REGISTRY_FILE" OSORI_QUERY="$PROJECT_QUERY" OSORI_ROOT_FILTER="$ROOT_FILTER" python3 << 'PYEOF'
+import os
+import sys
+
+sys.path.insert(0, os.environ["OSORI_SCRIPT_DIR"])
+from registry_lib import filter_projects, load_registry, registry_projects
+
+query = os.environ["OSORI_QUERY"].strip().lower()
+root_filter = os.environ.get("OSORI_ROOT_FILTER", "").strip()
+
+res = load_registry(os.environ["OSORI_REG"], auto_migrate=True, make_backup_on_migrate=True)
+projects = filter_projects(registry_projects(res.registry), root_key=root_filter)
+
+if not projects:
+    if root_filter:
+        print(f"❌ no projects found in root '{root_filter}'", file=sys.stderr)
+    else:
+        print("❌ no projects registered", file=sys.stderr)
+    raise SystemExit(1)
+
+exact = [p for p in projects if str(p.get("name", "")).lower() == query]
+candidates = exact if exact else [p for p in projects if query in str(p.get("name", "")).lower()]
+
+if not candidates:
+    suffix = f" in root '{root_filter}'" if root_filter else ""
+    print(f"❌ project '{os.environ['OSORI_QUERY']}' not found{suffix}", file=sys.stderr)
+    raise SystemExit(1)
+
+if len(candidates) > 1:
+    print(f"❌ ambiguous project query '{os.environ['OSORI_QUERY']}'. matches:", file=sys.stderr)
+    for i, p in enumerate(candidates[:10], start=1):
+        print(f"  {i}. {p.get('name', '-')} [{p.get('root', 'default')}] | {p.get('path', '-')}", file=sys.stderr)
+    raise SystemExit(1)
+
+target = candidates[0]
+name = str(target.get("name", "")).strip()
+path = str(target.get("path", "")).strip()
+root = str(target.get("root", "default") or "default")
+
+if not name or not path:
+    print("❌ invalid project entry (missing name/path)", file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"{name}\t{path}\t{root}")
+PYEOF
+)
+
+  IFS=$'\t' read -r PROJECT_NAME PROJECT_PATH PROJECT_ROOT <<< "$resolved"
+
+  if [[ -z "$PROJECT_PATH" || ! -d "$PROJECT_PATH" ]]; then
+    echo "❌ project path does not exist: $PROJECT_PATH"
+    exit 1
+  fi
+}
+
+run_for_project() {
+  echo "📁 *$PROJECT_NAME*"
+  echo "📍 $PROJECT_PATH"
+  echo "🧭 root: $PROJECT_ROOT"
+  echo
+
+  local cwd
+  cwd="$(pwd)"
+  cd "$PROJECT_PATH"
+
+  case "$COMMAND" in
+    status)
+      entire status --detailed
+      ;;
+    enable)
+      local has_agent="false"
+      local has_strategy="false"
+      local -a enable_args=()
+
+      for arg in "${EXTRA_ARGS[@]-}"; do
+        [[ -z "$arg" ]] && continue
+        enable_args+=("$arg")
+      done
+
+      for arg in "${enable_args[@]-}"; do
+        case "$arg" in
+          --agent|--agent=*) has_agent="true" ;;
+          --strategy|--strategy=*) has_strategy="true" ;;
+        esac
+      done
+      if [[ "$has_agent" != "true" ]]; then
+        enable_args+=("--agent" "claude-code")
+      fi
+      if [[ "$has_strategy" != "true" ]]; then
+        enable_args+=("--strategy" "manual-commit")
+      fi
+
+      if [[ "${enable_args[*]-}" != "" ]]; then
+        entire enable "${enable_args[@]}"
+      else
+        entire enable
+      fi
+      ;;
+    rewind-list)
+      entire rewind --list
+      ;;
+    *)
+      cd "$cwd"
+      echo "❌ unsupported command: $COMMAND"
+      exit 1
+      ;;
+  esac
+
+  cd "$cwd"
+}
+
+case "$COMMAND" in
+  status|enable|rewind-list)
+    ensure_entire
+    parse_target_and_extra "$@"
+    resolve_project
+    run_for_project
+    ;;
+  -h|--help|help|"")
+    usage
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/scripts/telegram-commands.sh
+++ b/scripts/telegram-commands.sh
@@ -37,6 +37,9 @@ show_help() {
 /favorites — Show favorite projects
 /favorite-add <project> — Mark project as favorite
 /favorite-remove <project> — Unmark favorite
+/entire-status <project> [root|--root <root>] — Show Entire status in project
+/entire-enable <project> [root|--root <root>] [--agent <name>] [--strategy <name>] — Enable Entire in project
+/entire-rewind-list <project> [root|--root <root>] — List Entire rewind points (JSON)
 /add <path> — Add project to registry
 /remove <name> — Remove project from registry
 /scan <path> [root] — Scan directory for projects (optional root key)
@@ -56,6 +59,8 @@ show_help() {
 `/root-remove work --reassign default`
 `/alias-add rh RunnersHeart`
 `/favorites`
+`/entire-status osori`
+`/entire-enable osori --agent claude-code --strategy manual-commit`
 `/scan /path/to/workspace work`
 EOF
 }
@@ -734,6 +739,21 @@ cmd_favorite_remove() {
     bash "$SCRIPT_DIR/alias-favorite-manager.sh" favorite-remove "$project"
 }
 
+cmd_entire_status() {
+    [[ $# -lt 1 ]] && { echo "❌ Usage: /entire-status <project> [root|--root <root>]"; exit 1; }
+    bash "$SCRIPT_DIR/entire-manager.sh" status "$@"
+}
+
+cmd_entire_enable() {
+    [[ $# -lt 1 ]] && { echo "❌ Usage: /entire-enable <project> [root|--root <root>] [--agent <name>] [--strategy <name>]"; exit 1; }
+    bash "$SCRIPT_DIR/entire-manager.sh" enable "$@"
+}
+
+cmd_entire_rewind_list() {
+    [[ $# -lt 1 ]] && { echo "❌ Usage: /entire-rewind-list <project> [root|--root <root>]"; exit 1; }
+    bash "$SCRIPT_DIR/entire-manager.sh" rewind-list "$@"
+}
+
 # Main dispatch
 command="${1:-help}"
 if [[ $# -gt 0 ]]; then
@@ -758,6 +778,9 @@ case "$command" in
     favorites) cmd_favorites ;;
     favorite-add) cmd_favorite_add "${1:-}" ;;
     favorite-remove) cmd_favorite_remove "${1:-}" ;;
+    entire-status) cmd_entire_status "$@" ;;
+    entire-enable) cmd_entire_enable "$@" ;;
+    entire-rewind-list) cmd_entire_rewind_list "$@" ;;
     add) cmd_add "${1:-}" ;;
     remove) cmd_remove "${1:-}" ;;
     scan) cmd_scan "${1:-}" "${2:-}" ;;

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -606,6 +606,38 @@ assert_contains "favorites empty message" "$favs_out2" "No favorite projects"
 teardown_test
 
 echo ""
+echo "=== test_entire_manager_commands ==="
+setup_test
+
+bash "$PROJECT_ROOT/scripts/add-project.sh" "$TEST_TMP/fake-project" --name "entire-proj" >/dev/null 2>&1
+FAKE_BIN="$TEST_TMP/fake-bin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/entire" << 'FAKEEOF'
+#!/usr/bin/env bash
+echo "FAKE_ENTIRE cwd=$(pwd) args=$*"
+FAKEEOF
+chmod +x "$FAKE_BIN/entire"
+
+ent_status_out=$(PATH="$FAKE_BIN:$PATH" bash "$PROJECT_ROOT/scripts/telegram-commands.sh" entire-status entire-proj 2>&1)
+assert_contains "entire-status uses fake cli" "$ent_status_out" "FAKE_ENTIRE"
+assert_contains "entire-status runs detailed status" "$ent_status_out" "args=status --detailed"
+assert_contains "entire-status runs in project path" "$ent_status_out" "cwd=$TEST_TMP/fake-project"
+
+ent_rewind_out=$(PATH="$FAKE_BIN:$PATH" bash "$PROJECT_ROOT/scripts/telegram-commands.sh" entire-rewind-list entire-proj 2>&1)
+assert_contains "entire-rewind-list runs list mode" "$ent_rewind_out" "args=rewind --list"
+
+ent_enable_default_out=$(PATH="$FAKE_BIN:$PATH" bash "$PROJECT_ROOT/scripts/telegram-commands.sh" entire-enable entire-proj 2>&1)
+assert_contains "entire-enable default command" "$ent_enable_default_out" "args=enable"
+assert_contains "entire-enable defaults agent" "$ent_enable_default_out" "--agent claude-code"
+assert_contains "entire-enable defaults strategy" "$ent_enable_default_out" "--strategy manual-commit"
+
+ent_enable_custom_out=$(PATH="$FAKE_BIN:$PATH" bash "$PROJECT_ROOT/scripts/telegram-commands.sh" entire-enable entire-proj --agent gemini --strategy auto-commit --local 2>&1)
+assert_contains "entire-enable custom agent forwarded" "$ent_enable_custom_out" "--agent gemini"
+assert_contains "entire-enable custom strategy forwarded" "$ent_enable_custom_out" "--strategy auto-commit"
+assert_contains "entire-enable custom local flag forwarded" "$ent_enable_custom_out" "--local"
+teardown_test
+
+echo ""
 echo "=== test_switch_root_filter ==="
 setup_test
 export OSORI_ROOT_KEY="work"
@@ -719,6 +751,7 @@ echo "=== test_platform_notes ==="
 skill_content=$(cat "$PROJECT_ROOT/SKILL.md")
 assert_contains "SKILL.md mentions mdfind is macOS only" "$skill_content" "macOS"
 assert_contains "SKILL.md mentions python3 dependency" "$skill_content" "python3"
+assert_contains "SKILL.md mentions entire integration" "$skill_content" "entire"
 
 # Summary
 echo ""


### PR DESCRIPTION
## Summary
- add project-aware Entire wrapper script: `scripts/entire-manager.sh`
  - `status <project> [root|--root <root>]`
  - `enable <project> [root|--root <root>] [entire enable flags...]`
  - `rewind-list <project> [root|--root <root>]`
- wire Telegram commands
  - `/entire-status`
  - `/entire-enable`
  - `/entire-rewind-list`
- commit baseline Entire/Claude integration config
  - `.entire/settings.json`, `.entire/.gitignore`
  - `.claude/settings.json` (Entire hooks)
- update `SKILL.md` docs, setup examples, and dependencies for Entire integration
- add tests for Entire command routing + argument forwarding in `tests/run_tests.sh`

## Test
- `./tests/run_tests.sh`
- Result: **85 passed, 0 failed**
