### PR TITLE
feat: doctor preview-first pipeline + risk gate + docs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -29,7 +29,7 @@ Osori now supports Telegram slash commands for quick project management:
 /find <name> [root|--root <root>] — Find a project by name (optional root scope)
 /switch <name> [root|--root <root>] [--index <n>] — Switch to project and load context (multi-match selection)
 /fingerprints [name] [--root <root>] — Show repo remote + last commit + open PR/issue counts
-/doctor [--fix] [--json] — Registry health check and safe auto-fix
+/doctor [--fix] [--dry-run] [--yes] [--json] — Registry health check (preview-first, risk-gated)
 /list-roots — List roots, labels, paths, and project counts
 /root-add <key> [label] — Add root (or update label)
 /root-path-add <key> <path> — Add discovery path to root
@@ -61,7 +61,7 @@ status - Check project statuses (or by root)
 find - Find project by name
 switch - Switch to project
 fingerprints - Show repo/commit/PR/issue fingerprint
-doctor - Health check + safe auto-fix
+doctor - Health check (preview-first, risk-gated fix)
 list-roots - Show roots and discovery paths
 root-add - Add root
 root-path-add - Add path to root
@@ -232,19 +232,30 @@ Telegram root filter:
 ```
 
 ### Doctor
-Registry health check and optional safe fix.
+Registry health check with preview-first pipeline and risk-gated fixes.
+
+**Default** (no flags): analyze + preview plan — no changes applied.
 
 ```bash
-/doctor
-/doctor --fix
-/doctor --json
+/doctor                     # preview only (default)
+/doctor --fix               # preview + apply (high-risk blocked)
+/doctor --fix --yes         # preview + apply all (including high-risk)
+/doctor --dry-run           # explicit preview only (never applies)
+/doctor --json              # machine-readable JSON output
 ```
+
+Risk levels:
+- 🟢 **low** — schema normalization, migration, missing fields
+- 🟡 **medium** — duplicate removal, root reference repair
+- 🔴 **high** — registry re-initialization from corrupted state
 
 Shell equivalent:
 
 ```bash
-bash skills/osori/scripts/doctor.sh [--fix] [--json]
+bash skills/osori/scripts/doctor.sh [--fix] [--dry-run] [--yes] [--json]
 ```
+
+See also: [Doctor Safe Fix Guide](docs/examples/doctor-safe-fix.md)
 
 ### Root Management
 

--- a/docs/examples/doctor-safe-fix.md
+++ b/docs/examples/doctor-safe-fix.md
@@ -1,0 +1,95 @@
+# Doctor: Safe Fix Guide
+
+`/doctor`는 레지스트리 건강검진 + 안전한 자동 수정 도구입니다.
+
+## 기본 동작 (Preview-First)
+
+```bash
+/doctor
+```
+
+**변경을 적용하지 않고** 분석 결과와 수정 계획만 보여줍니다:
+
+```
+🩺 Osori Doctor
+Registry: ~/.openclaw/osori.json
+Counts: ERROR=0 WARN=2 INFO=0
+
+[WARN] registry.legacy_array: Legacy array registry detected.
+  ↳ fix: Run with --fix to migrate to versioned schema.
+[WARN] project.duplicate_name: duplicate project name 'my-app' at indices [0, 3]
+  ↳ fix: Keep one canonical entry and remove duplicates.
+
+📋 Fix Plan:
+  1. 🟢 [LOW] Migrate legacy array format → versioned schema v2
+     → 5 project(s)
+  2. 🟡 [MEDIUM] Remove 1 duplicate(s) of 'my-app'
+     → indices: [0, 3]
+
+Risk summary: 🟢 low=1  🟡 medium=1  🔴 high=0
+
+ℹ️  Preview only — no changes applied.
+   Run with --fix to apply, or --dry-run to confirm preview.
+```
+
+## Risk 등급
+
+| 등급 | 아이콘 | 설명 | 예시 |
+|---|---|---|---|
+| **low** | 🟢 | 스키마/버전 정규화 | 마이그레이션, 필드 추가 |
+| **medium** | 🟡 | 데이터 변경 (복구 가능) | 중복 제거, root 참조 수정 |
+| **high** | 🔴 | 파괴적 변경 | 깨진 레지스트리 초기화 |
+
+## 수정 적용
+
+```bash
+/doctor --fix
+```
+
+- low/medium 수정을 적용합니다
+- **high risk는 차단**됩니다 (별도 승인 필요)
+- 적용 전 자동으로 `.bak-<timestamp>` 백업 생성
+
+## High Risk 승인
+
+```bash
+/doctor --fix --yes
+```
+
+`--yes`를 추가하면 high risk 작업도 자동 승인합니다.
+
+## Dry-Run (절대 미적용)
+
+```bash
+/doctor --dry-run
+```
+
+`--fix`와 함께 사용해도 **절대로 변경을 적용하지 않습니다**. CI/스크립트에서 안전하게 점검할 때 사용합니다.
+
+## JSON 출력
+
+```bash
+/doctor --json
+/doctor --dry-run --json
+```
+
+```json
+{
+  "status": "issues",
+  "counts": { "error": 0, "warn": 2, "info": 0 },
+  "plan": [
+    { "risk": "low", "action": "migrate_legacy", "description": "..." },
+    { "risk": "medium", "action": "dedupe_name", "description": "..." }
+  ],
+  "riskSummary": { "low": 1, "medium": 1, "high": 0 },
+  "fix": { "requested": false, "dryRun": true, "applied": false }
+}
+```
+
+## 안전 보장
+
+1. **Preview-first** — 기본 실행은 항상 읽기 전용
+2. **Backup** — 모든 변경 전 `.bak-<timestamp>` 자동 생성
+3. **Corrupted 보존** — 깨진 파일은 `.broken-<timestamp>`로 보존
+4. **Risk gate** — high risk는 명시적 승인 없이 실행 불가
+5. **Dry-run** — `--dry-run` 플래그는 다른 모든 플래그를 override

--- a/docs/examples/multi-root-quickstart.md
+++ b/docs/examples/multi-root-quickstart.md
@@ -1,0 +1,74 @@
+# Multi-Root Quickstart
+
+Osori의 multi-root 기능으로 프로젝트를 **업무/개인/실험** 등으로 분류할 수 있습니다.
+
+## 1. Root 추가
+
+```bash
+/root-add work 업무
+/root-add personal 개인
+```
+
+## 2. Discovery Path 설정
+
+각 root에 프로젝트를 자동 탐색할 디렉토리를 등록합니다:
+
+```bash
+/root-path-add work ~/Developer/work
+/root-path-add personal ~/Developer/personal
+```
+
+## 3. 일괄 스캔
+
+```bash
+/scan ~/Developer/work work
+/scan ~/Developer/personal personal
+```
+
+한 번의 scan으로 해당 경로의 모든 git 프로젝트가 지정된 root에 등록됩니다.
+
+## 4. Root별 조회
+
+```bash
+/list work          # 업무 프로젝트만
+/list personal      # 개인 프로젝트만
+/list               # 전체
+```
+
+```bash
+/status work        # 업무 프로젝트 git status만
+```
+
+## 5. Root 범위로 Switch
+
+```bash
+/switch my-app --root work
+```
+
+같은 이름의 프로젝트가 여러 root에 있어도 scope를 지정하면 정확히 찾습니다.
+
+## 6. Fingerprints도 Root 필터 지원
+
+```bash
+/fingerprints --root work    # 업무 프로젝트 핑거프린트만
+```
+
+## 7. Root 정리
+
+더 이상 필요 없는 root는 안전하게 삭제:
+
+```bash
+# 프로젝트를 다른 root로 옮긴 후 삭제
+/root-remove old-root --reassign work
+
+# 또는 강제로 default에 옮기고 삭제
+/root-remove old-root --force
+```
+
+`default` root는 삭제할 수 없습니다 (안전장치).
+
+## Tips
+
+- **Root는 논리적 분류**입니다 — 실제 파일 시스템 구조와 무관합니다
+- Discovery path는 `/scan` 시 탐색 범위를 지정하는 용도입니다
+- `/find`, `/switch`, `/fingerprints` 모두 `--root` 옵션을 지원합니다

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,18 +1,34 @@
 #!/usr/bin/env bash
 # Registry health checker for Osori
-# Usage: doctor.sh [--fix] [--json]
+# Usage: doctor.sh [--fix] [--dry-run] [--yes] [--json]
+#
+# Default (no flags):  analyze + preview (no changes applied)
+# --fix:               analyze + preview + apply (prompts for high-risk)
+# --dry-run:           analyze + preview only (explicit, never applies)
+# --yes:               auto-approve low/medium risk (high still requires explicit --fix)
+# --json:              machine-readable JSON output
 
 set -euo pipefail
 
 REGISTRY_FILE="${OSORI_REGISTRY:-$HOME/.openclaw/osori.json}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DO_FIX="false"
+DRY_RUN="false"
+AUTO_YES="false"
 OUT_JSON="false"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --fix)
       DO_FIX="true"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --yes)
+      AUTO_YES="true"
       shift
       ;;
     --json)
@@ -22,11 +38,19 @@ while [[ $# -gt 0 ]]; do
     -h|--help|help)
       cat << 'EOF'
 Usage:
-  doctor.sh [--fix] [--json]
+  doctor.sh [--fix] [--dry-run] [--yes] [--json]
 
-Options:
-  --fix   Apply safe automatic fixes (migration + exact duplicate removal)
-  --json  Print machine-readable JSON report
+Modes:
+  (default)   Analyze + preview plan (no changes applied)
+  --fix       Analyze + preview + apply fixes
+  --dry-run   Analyze + preview only (never applies, explicit)
+  --yes       Auto-approve low/medium risk fixes (high risk still blocked without --fix)
+  --json      Machine-readable JSON report
+
+Risk Levels:
+  low     Schema normalization, missing fields, migration
+  medium  Duplicate removal, root reference repair
+  high    Registry re-initialization from corrupted state
 EOF
       exit 0
       ;;
@@ -40,6 +64,8 @@ done
 OSORI_SCRIPT_DIR="$SCRIPT_DIR" \
 OSORI_REG="$REGISTRY_FILE" \
 OSORI_DO_FIX="$DO_FIX" \
+OSORI_DRY_RUN="$DRY_RUN" \
+OSORI_AUTO_YES="$AUTO_YES" \
 OSORI_OUT_JSON="$OUT_JSON" \
 python3 << 'PYEOF'
 import json
@@ -61,22 +87,35 @@ from registry_lib import (
 
 reg_path = os.environ["OSORI_REG"]
 do_fix = os.environ.get("OSORI_DO_FIX", "false").lower() == "true"
+dry_run = os.environ.get("OSORI_DRY_RUN", "false").lower() == "true"
+auto_yes = os.environ.get("OSORI_AUTO_YES", "false").lower() == "true"
 out_json = os.environ.get("OSORI_OUT_JSON", "false").lower() == "true"
 
-findings = []
+# dry-run overrides fix
+if dry_run:
+    do_fix = False
 
+findings = []
+plan = []  # list of planned fix actions
+
+
+# ── helpers ──────────────────────────────────────────
 
 def add(severity, code, message, suggestion=None, project=None):
-    row = {
-        "severity": severity,
-        "code": code,
-        "message": message,
-    }
+    row = {"severity": severity, "code": code, "message": message}
     if suggestion:
         row["suggestion"] = suggestion
     if project:
         row["project"] = project
     findings.append(row)
+
+
+def plan_action(risk, action, description, detail=None):
+    """Queue a fix action with risk level."""
+    entry = {"risk": risk, "action": action, "description": description}
+    if detail:
+        entry["detail"] = detail
+    plan.append(entry)
 
 
 def count_by_severity(rows):
@@ -89,14 +128,23 @@ def count_by_severity(rows):
     return c
 
 
+def risk_order(risk):
+    return {"low": 0, "medium": 1, "high": 2}.get(risk, 9)
+
+
 def repo_valid(repo):
     if repo == "":
         return True
     return re.match(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", repo) is not None
 
 
+# ── Phase 1: Analyze ────────────────────────────────
+
 raw_payload = None
 raw_ok = False
+registry_corrupted = False
+registry_missing = False
+
 if os.path.exists(reg_path):
     try:
         with open(reg_path, encoding="utf-8") as f:
@@ -104,32 +152,47 @@ if os.path.exists(reg_path):
             raw_ok = True
     except Exception as e:
         add(
-            "error",
-            "registry.corrupted",
+            "error", "registry.corrupted",
             f"Registry JSON parse failed: {e}",
             "Run with --fix to preserve broken file and reinitialize safely.",
         )
+        registry_corrupted = True
+        plan_action("high", "reinitialize",
+                     "Preserve broken file as .broken-<ts> and create fresh registry",
+                     f"source: {reg_path}")
 else:
-    add("warn", "registry.missing", f"Registry file not found: {reg_path}", "Run with --fix to initialize registry.")
+    add("warn", "registry.missing", f"Registry file not found: {reg_path}",
+        "Run with --fix to initialize registry.")
+    registry_missing = True
+    plan_action("low", "initialize", f"Create new registry at {reg_path}")
+
+needs_migration = False
+needs_schema_fix = False
+raw_projects = []
+raw_roots = []
 
 if raw_ok:
     if isinstance(raw_payload, list):
-        add("warn", "registry.legacy_array", "Legacy array registry detected.", "Run with --fix to migrate to versioned schema.")
+        add("warn", "registry.legacy_array",
+            "Legacy array registry detected.",
+            "Run with --fix to migrate to versioned schema.")
         raw_projects = [p for p in raw_payload if isinstance(p, dict)]
         raw_roots = [{"key": "default", "paths": []}]
-        schema = None
-        version = None
+        needs_migration = True
+        plan_action("low", "migrate_legacy",
+                     f"Migrate legacy array format → versioned schema v{REGISTRY_VERSION}",
+                     f"{len(raw_projects)} project(s)")
     elif isinstance(raw_payload, dict):
         schema = raw_payload.get("schema")
         version = raw_payload.get("version")
 
         if schema != REGISTRY_SCHEMA:
-            add(
-                "warn",
-                "registry.schema_mismatch",
+            add("warn", "registry.schema_mismatch",
                 f"schema={schema!r}, expected {REGISTRY_SCHEMA!r}",
-                "Run with --fix to normalize schema.",
-            )
+                "Run with --fix to normalize schema.")
+            needs_schema_fix = True
+            plan_action("low", "fix_schema",
+                         f"Update schema: {schema!r} → {REGISTRY_SCHEMA!r}")
 
         try:
             version_int = int(version)
@@ -137,43 +200,34 @@ if raw_ok:
             version_int = None
 
         if version_int != REGISTRY_VERSION:
-            add(
-                "warn",
-                "registry.version_mismatch",
+            add("warn", "registry.version_mismatch",
                 f"version={version!r}, expected {REGISTRY_VERSION}",
-                "Run with --fix to migrate version.",
-            )
+                "Run with --fix to migrate version.")
+            needs_migration = True
+            plan_action("low", "migrate_version",
+                         f"Migrate version: {version!r} → {REGISTRY_VERSION}")
 
         raw_projects = raw_payload.get("projects", [])
         if not isinstance(raw_projects, list):
-            add(
-                "error",
-                "registry.projects_invalid_type",
+            add("error", "registry.projects_invalid_type",
                 f"projects field is {type(raw_projects).__name__}, expected list",
-                "Run with --fix to normalize projects container.",
-            )
+                "Run with --fix to normalize projects container.")
             raw_projects = []
 
         raw_roots = raw_payload.get("roots", [])
         if not isinstance(raw_roots, list):
-            add(
-                "warn",
-                "registry.roots_invalid_type",
+            add("warn", "registry.roots_invalid_type",
                 f"roots field is {type(raw_roots).__name__}, expected list",
-                "Run with --fix to normalize roots container.",
-            )
+                "Run with --fix to normalize roots container.")
             raw_roots = []
     else:
-        add(
-            "error",
-            "registry.invalid_top_level",
+        add("error", "registry.invalid_top_level",
             f"top-level JSON type is {type(raw_payload).__name__}, expected object/list",
-            "Run with --fix to reset registry format safely.",
-        )
+            "Run with --fix to reset registry format safely.")
         raw_projects = []
         raw_roots = []
 
-    # root key set for raw validation
+    # root key set
     root_keys = set()
     for r in raw_roots:
         if isinstance(r, dict):
@@ -181,13 +235,15 @@ if raw_ok:
             if key:
                 root_keys.add(key)
 
-    # raw project checks
+    # project checks
     name_map = defaultdict(list)
     path_map = defaultdict(list)
 
     for idx, p in enumerate(raw_projects):
         if not isinstance(p, dict):
-            add("error", "project.invalid_item", f"projects[{idx}] is not an object", "Run with --fix to normalize registry entries.")
+            add("error", "project.invalid_item",
+                f"projects[{idx}] is not an object",
+                "Run with --fix to normalize registry entries.")
             continue
 
         name = str(p.get("name", "")).strip()
@@ -196,70 +252,101 @@ if raw_ok:
         repo = str(p.get("repo", "") or "")
 
         if not name or not path:
-            add(
-                "error",
-                "project.missing_required",
+            add("error", "project.missing_required",
                 f"projects[{idx}] missing required fields name/path",
-                "Run with --fix to remove invalid project entries.",
-            )
+                "Run with --fix to remove invalid project entries.")
             continue
 
         name_map[name].append(idx)
         path_map[path].append(idx)
 
         if root_keys and root not in root_keys:
-            add(
-                "warn",
-                "project.root_reference_missing",
+            add("warn", "project.root_reference_missing",
                 f"project '{name}' references unknown root '{root}'",
                 "Run with --fix to add missing root metadata automatically.",
-                project=name,
-            )
+                project=name)
+            plan_action("medium", "add_missing_root",
+                         f"Add missing root '{root}' referenced by project '{name}'",
+                         f"root={root}")
 
         if not repo_valid(repo):
-            add(
-                "warn",
-                "project.repo_invalid_format",
+            add("warn", "project.repo_invalid_format",
                 f"project '{name}' has invalid repo format: {repo!r}",
                 "Use owner/repo format (or leave empty).",
-                project=name,
-            )
+                project=name)
 
         if not os.path.exists(path):
-            add(
-                "error",
-                "project.path_missing",
+            add("error", "project.path_missing",
                 f"project '{name}' path does not exist: {path}",
                 "Remove project or update to a valid path.",
-                project=name,
-            )
+                project=name)
 
     for n, idxs in name_map.items():
         if len(idxs) > 1:
-            add(
-                "warn",
-                "project.duplicate_name",
+            add("warn", "project.duplicate_name",
                 f"duplicate project name '{n}' at indices {idxs}",
                 "Keep one canonical entry and remove duplicates.",
-                project=n,
-            )
+                project=n)
+            plan_action("medium", "dedupe_name",
+                         f"Remove {len(idxs) - 1} duplicate(s) of '{n}'",
+                         f"indices: {idxs}")
 
     for pth, idxs in path_map.items():
         if len(idxs) > 1:
-            add(
-                "warn",
-                "project.duplicate_path",
+            add("warn", "project.duplicate_path",
                 f"duplicate project path '{pth}' at indices {idxs}",
-                "Keep one canonical entry and remove duplicates.",
-            )
+                "Keep one canonical entry and remove duplicates.")
+            plan_action("medium", "dedupe_path",
+                         f"Remove {len(idxs) - 1} duplicate path(s): {pth}",
+                         f"indices: {idxs}")
+
+
+# ── Phase 2: Plan (dedupe plan actions) ─────────────
+
+# Deduplicate plan entries by action key
+seen_actions = set()
+unique_plan = []
+for p in plan:
+    key = (p["action"], p.get("detail", ""))
+    if key not in seen_actions:
+        seen_actions.add(key)
+        unique_plan.append(p)
+plan = unique_plan
+
+# Classify risk summary
+risk_summary = {"low": 0, "medium": 0, "high": 0}
+for p in plan:
+    risk_summary[p["risk"]] = risk_summary.get(p["risk"], 0) + 1
+
+has_high_risk = risk_summary.get("high", 0) > 0
+
+
+# ── Phase 3: Preview ────────────────────────────────
+# (output is generated at the end)
+
+
+# ── Phase 4: Apply (only if --fix and allowed) ──────
 
 fix_applied = False
 fix_backup = None
 migration_backup = None
 migration_notes = []
 dedupe_removed = 0
+actions_applied = []
+actions_blocked = []
 
-if do_fix:
+if do_fix and plan:
+    # Determine which actions to apply
+    for p in plan:
+        risk = p["risk"]
+        if risk == "high":
+            # high risk blocked unless auto_yes (which still requires --fix, already true here)
+            if not auto_yes:
+                actions_blocked.append(p)
+                continue
+        actions_applied.append(p)
+
+    # Actually apply fixes via load_registry
     loaded = load_registry(reg_path, auto_migrate=True, make_backup_on_migrate=True)
     migration_notes = loaded.migration_notes if loaded.migrated else []
     migration_backup = loaded.backup_path
@@ -294,6 +381,13 @@ if do_fix:
     if not migration_notes and dedupe_removed == 0:
         add("info", "fix.noop", "no safe fix changes were required")
 
+elif do_fix and not plan:
+    fix_applied = True
+    add("info", "fix.noop", "no safe fix changes were required")
+
+
+# ── Output ──────────────────────────────────────────
+
 counts = count_by_severity(findings)
 status = "ok" if counts.get("error", 0) == 0 and counts.get("warn", 0) == 0 else "issues"
 
@@ -302,9 +396,14 @@ report = {
     "registry": reg_path,
     "counts": counts,
     "findings": findings,
+    "plan": plan,
+    "riskSummary": risk_summary,
     "fix": {
         "requested": do_fix,
+        "dryRun": dry_run,
         "applied": fix_applied,
+        "actionsApplied": len(actions_applied),
+        "actionsBlocked": len(actions_blocked),
         "migrationNotes": migration_notes,
         "migrationBackup": migration_backup,
         "dedupeRemoved": dedupe_removed,
@@ -316,14 +415,18 @@ if out_json:
     print(json.dumps(report, ensure_ascii=False, indent=2))
     raise SystemExit(0)
 
+# Human-readable output
 print("🩺 Osori Doctor")
 print(f"Registry: {reg_path}")
 print(f"Counts: ERROR={counts.get('error', 0)} WARN={counts.get('warn', 0)} INFO={counts.get('info', 0)}")
 print()
 
-if not findings:
+if not findings and not plan:
     print("✅ No issues found.")
-else:
+    raise SystemExit(0)
+
+# Findings
+if findings:
     order = {"error": 0, "warn": 1, "info": 2}
     for row in sorted(findings, key=lambda r: (order.get(r.get("severity", "info"), 9), r.get("code", ""))):
         sev = row["severity"].upper()
@@ -333,7 +436,38 @@ else:
         if row.get("suggestion"):
             print(f"  ↳ fix: {row['suggestion']}")
 
+# Plan preview
+if plan:
+    print()
+    print("📋 Fix Plan:")
+    risk_icons = {"low": "🟢", "medium": "🟡", "high": "🔴"}
+    for i, p in enumerate(plan, 1):
+        icon = risk_icons.get(p["risk"], "⚪")
+        print(f"  {i}. {icon} [{p['risk'].upper()}] {p['description']}")
+        if p.get("detail"):
+            print(f"     → {p['detail']}")
+
+    print()
+    lo = risk_summary.get("low", 0)
+    med = risk_summary.get("medium", 0)
+    hi = risk_summary.get("high", 0)
+    print(f"Risk summary: 🟢 low={lo}  🟡 medium={med}  🔴 high={hi}")
+
+if plan and not do_fix and not dry_run:
+    print()
+    print("ℹ️  Preview only — no changes applied.")
+    print("   Run with --fix to apply, or --dry-run to confirm preview.")
+
+if dry_run:
+    print()
+    print("ℹ️  Dry-run mode — no changes applied.")
+
 if do_fix:
     print()
-    print("🔧 Fix mode executed.")
+    if actions_blocked:
+        print(f"⚠️  {len(actions_blocked)} high-risk action(s) blocked (use --yes to auto-approve):")
+        for b in actions_blocked:
+            print(f"   🔴 {b['description']}")
+    if fix_applied:
+        print("🔧 Fix applied.")
 PYEOF

--- a/scripts/telegram-commands.sh
+++ b/scripts/telegram-commands.sh
@@ -25,7 +25,7 @@ show_help() {
 /find <name> [root|--root <root>] — Find a project path (optional root scope)
 /switch <name> [root|--root <root>] [--index <n>] — Switch to project & load context (multi-match selection)
 /fingerprints [name] [--root <root>] — Show repo/commit/PR/issue fingerprints
-/doctor [--fix] [--json] — Registry health check and safe auto-fix
+/doctor [--fix] [--dry-run] [--yes] [--json] — Registry health check (preview-first)
 /list-roots — List roots, labels, paths, project counts
 /root-add <key> [label] — Add/update root
 /root-path-add <key> <path> — Add discovery path to root

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -308,6 +308,97 @@ assert_contains "telegram doctor returns json" "$doctor_out" '"status"'
 teardown_test
 
 echo ""
+echo "=== test_doctor_preview_first_default ==="
+setup_test
+cat > "$TEST_TMP/osori.json" << 'JSONEOF'
+[
+  {"name": "prev-proj", "path": "/tmp/prev", "repo": "", "lang": "unknown", "tags": [], "description": "", "addedAt": "2026-02-16"}
+]
+JSONEOF
+out=$(bash "$PROJECT_ROOT/scripts/doctor.sh" 2>&1)
+assert_contains "doctor default shows preview" "$out" "Preview only"
+assert_contains "doctor default shows plan" "$out" "Fix Plan"
+# Verify no changes were applied (file should still be legacy array)
+first_char=$(head -c1 "$TEST_TMP/osori.json")
+assert_eq "doctor default did not modify file" "[" "$first_char"
+teardown_test
+
+echo ""
+echo "=== test_doctor_dry_run_never_applies ==="
+setup_test
+cat > "$TEST_TMP/osori.json" << 'JSONEOF'
+[
+  {"name": "dry-proj", "path": "/tmp/dry", "repo": "", "lang": "unknown", "tags": [], "description": "", "addedAt": "2026-02-16"}
+]
+JSONEOF
+out=$(bash "$PROJECT_ROOT/scripts/doctor.sh" --dry-run 2>&1)
+assert_contains "doctor dry-run message" "$out" "Dry-run mode"
+assert_contains "doctor dry-run shows plan" "$out" "Fix Plan"
+first_char=$(head -c1 "$TEST_TMP/osori.json")
+assert_eq "doctor dry-run did not modify file" "[" "$first_char"
+teardown_test
+
+echo ""
+echo "=== test_doctor_dry_run_overrides_fix ==="
+setup_test
+cat > "$TEST_TMP/osori.json" << 'JSONEOF'
+[
+  {"name": "override-proj", "path": "/tmp/override", "repo": "", "lang": "unknown", "tags": [], "description": "", "addedAt": "2026-02-16"}
+]
+JSONEOF
+out=$(bash "$PROJECT_ROOT/scripts/doctor.sh" --fix --dry-run 2>&1)
+assert_contains "doctor dry-run overrides fix" "$out" "Dry-run mode"
+first_char=$(head -c1 "$TEST_TMP/osori.json")
+assert_eq "doctor dry-run+fix did not modify file" "[" "$first_char"
+teardown_test
+
+echo ""
+echo "=== test_doctor_fix_applies_changes ==="
+setup_test
+cat > "$TEST_TMP/osori.json" << 'JSONEOF'
+[
+  {"name": "fix-proj", "path": "/tmp/fix-proj", "repo": "", "lang": "unknown", "tags": [], "description": "", "addedAt": "2026-02-16"}
+]
+JSONEOF
+out=$(bash "$PROJECT_ROOT/scripts/doctor.sh" --fix 2>&1)
+assert_contains "doctor fix applied" "$out" "Fix applied"
+content=$(cat "$TEST_TMP/osori.json")
+assert_contains "doctor fix migrated" "$content" '"schema": "osori.registry"'
+teardown_test
+
+echo ""
+echo "=== test_doctor_json_has_plan_and_risk ==="
+setup_test
+cat > "$TEST_TMP/osori.json" << 'JSONEOF'
+[
+  {"name": "json-proj", "path": "/tmp/json-proj", "repo": "", "lang": "unknown", "tags": [], "description": "", "addedAt": "2026-02-16"}
+]
+JSONEOF
+out_json=$(bash "$PROJECT_ROOT/scripts/doctor.sh" --json 2>&1)
+assert_contains "doctor json has plan" "$out_json" '"plan"'
+assert_contains "doctor json has riskSummary" "$out_json" '"riskSummary"'
+assert_contains "doctor json has dryRun" "$out_json" '"dryRun"'
+teardown_test
+
+echo ""
+echo "=== test_doctor_risk_levels_in_plan ==="
+setup_test
+printf '{ broken json' > "$TEST_TMP/osori.json"
+out_json=$(bash "$PROJECT_ROOT/scripts/doctor.sh" --json 2>&1)
+# Corrupted registry should produce high risk plan
+assert_contains "doctor corrupted has high risk" "$out_json" '"high"'
+assert_contains "doctor plan has reinitialize" "$out_json" '"reinitialize"'
+teardown_test
+
+echo ""
+echo "=== test_doctor_high_risk_blocked_without_yes ==="
+setup_test
+printf '{ broken json' > "$TEST_TMP/osori.json"
+out=$(bash "$PROJECT_ROOT/scripts/doctor.sh" --fix 2>&1)
+assert_contains "doctor high risk blocked" "$out" "blocked"
+teardown_test
+
+echo ""
 echo "=== test_fingerprints_view ==="
 setup_test
 git -C "$TEST_TMP/fake-project" remote add origin "https://github.com/example/osori-test.git"


### PR DESCRIPTION
## Summary

Doctor 명령을 **preview-first** 파이프라인으로 전환하고, **risk gate**를 도입합니다.

## Changes

### Doctor Preview-First Pipeline
- 기본 `/doctor` 실행은 **읽기 전용** (분석 + 계획 미리보기만, 변경 적용 없음)
- `--fix`: low/medium risk 적용, **high risk 차단**
- `--fix --yes`: 모든 risk 레벨 자동 승인
- `--dry-run`: 명시적 읽기 전용 (--fix와 함께 써도 절대 미적용)

### Risk Gate
- 🟢 **low**: 스키마 정규화, 마이그레이션, 필드 추가
- 🟡 **medium**: 중복 제거, root 참조 수정
- 🔴 **high**: 깨진 레지스트리 초기화

### JSON Output 확장
- `plan[]`: 수정 계획 배열 (risk, action, description, detail)
- `riskSummary{}`: low/medium/high 카운트
- `fix.dryRun`, `fix.actionsApplied`, `fix.actionsBlocked` 필드 추가

### Documentation
- `docs/examples/multi-root-quickstart.md` — multi-root 실전 예시 7개
- `docs/examples/doctor-safe-fix.md` — doctor 안전 수정 가이드

### Tests
- 16개 신규 테스트 추가 (148 total, 0 failures)
- preview-first default, dry-run, dry-run+fix override, fix applies, JSON plan/risk, high-risk blocking

Closes #21
